### PR TITLE
Add kernel partition to image

### DIFF
--- a/HabaneroPnorLayout.xml
+++ b/HabaneroPnorLayout.xml
@@ -145,10 +145,16 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (22.5MB)</description>
+        <description>Skiboot Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0xC75000</physicalOffset>
-        <physicalRegionSize>0x1680000</physicalRegionSize>
+        <physicalRegionSize>0x100000</physicalRegionSize>
+    </section>
+    <section>
+        <description>Kernel (21.5MB)</description>
+        <eyeCatch>KERNEL</eyeCatch>
+        <physicalOffset>0xD75000</physicalOffset>
+        <physicalRegionSize>0x1580000</physicalRegionSize>
     </section>
     <section>
         <description>Temporary Attribute Override (32K)</description>

--- a/PalmettoPnorLayout.xml
+++ b/PalmettoPnorLayout.xml
@@ -160,10 +160,17 @@ Layout Description
         <ecc/>
     </section>
     <section> <!-- WGH DISCUSSION NEEDED ABOUT SHA512 + ECC, for now - neither -->
-        <description>Payload (16MB)</description>
+        <description>Skiboot Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0xA59000</physicalOffset>
-        <physicalRegionSize>0x1000000</physicalRegionSize>
+        <physicalRegionSize>0x100000</physicalRegionSize>
+        <side>A</side>  <!-- Choices: A, B -->
+    </section>
+    <section> <!-- WGH DISCUSSION NEEDED ABOUT SHA512 + ECC, for now - neither -->
+        <description>Kernel (15MB)</description>
+        <eyeCatch>KERNEL</eyeCatch>
+        <physicalOffset>0xB59000</physicalOffset>
+        <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>A</side>  <!-- Choices: A, B -->
     </section>
     <section>

--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -9,6 +9,7 @@ my $scratch_dir = "";
 my $pnor_data_dir = "";
 my $pnor_filename = "";
 my $payload = "";
+my $kernel = "";
 my $hb_image_dir = "";
 my $xml_layout_file = "";
 my $targeting_binary_filename = "";
@@ -51,6 +52,10 @@ while (@ARGV > 0){
     }
     elsif (/^-payload/i){
         $payload = $ARGV[1] or die "Bad command line arg given: expecting a filepath to payload binary file.\n";
+        shift;
+    }
+    elsif (/^-kernel/i){
+        $kernel = $ARGV[1] or die "Bad command line arg given: expecting a filepath to kernel image.\n";
         shift;
     }
     elsif (/^-targeting_binary_filename/i){
@@ -96,6 +101,7 @@ $build_pnor_command .= " --binFile_HBRT $scratch_dir/hostboot_runtime.header.bin
 $build_pnor_command .= " --binFile_HBEL $scratch_dir/hbel.bin.ecc";
 $build_pnor_command .= " --binFile_GUARD $scratch_dir/guard.bin.ecc";
 $build_pnor_command .= " --binFile_PAYLOAD $payload";
+$build_pnor_command .= " --binFile_KERNEL $kernel";
 $build_pnor_command .= " --binFile_NVRAM $scratch_dir/nvram.bin.ecc";
 $build_pnor_command .= " --binFile_MVPD $scratch_dir/mvpd_fill.bin.ecc";
 $build_pnor_command .= " --binFile_DJVPD $scratch_dir/djvpd_fill.bin.ecc";


### PR DESCRIPTION
The pnor will now contain a KERNEL partition, which holds the linux
kernel and initramfs that was previously placed in along with skiboot in
the PAYLOAD partition.

The PAYLOAD partition is shrunk to 1MB. Given skiboot is currently about
700KB, this should accommodate growth in the skiboot binary over time.
The remaining 15MB (21.5MB on the Habanero platform) is used for the
kernel and initramfs.

Signed-off-by: Joel Stanley <joel@jms.id.au>