### PR TITLE
Add kernel partition to image

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -9,6 +9,7 @@ my $scratch_dir = "";
 my $pnor_data_dir = "";
 my $pnor_filename = "";
 my $payload = "";
+my $bootkernel = "";
 my $hb_image_dir = "";
 my $xml_layout_file = "";
 my $targeting_binary_filename = "";
@@ -51,6 +52,10 @@ while (@ARGV > 0){
     }
     elsif (/^-payload/i){
         $payload = $ARGV[1] or die "Bad command line arg given: expecting a filepath to payload binary file.\n";
+        shift;
+    }
+    elsif (/^-bootkernel/i){
+        $bootkernel = $ARGV[1] or die "Bad command line arg given: expecting a filepath to bootloader kernel image.\n";
         shift;
     }
     elsif (/^-targeting_binary_filename/i){
@@ -96,6 +101,7 @@ $build_pnor_command .= " --binFile_HBRT $scratch_dir/hostboot_runtime.header.bin
 $build_pnor_command .= " --binFile_HBEL $scratch_dir/hbel.bin.ecc";
 $build_pnor_command .= " --binFile_GUARD $scratch_dir/guard.bin.ecc";
 $build_pnor_command .= " --binFile_PAYLOAD $payload";
+$build_pnor_command .= " --binFile_BOOTKERNEL $bootkernel";
 $build_pnor_command .= " --binFile_NVRAM $scratch_dir/nvram.bin.ecc";
 $build_pnor_command .= " --binFile_MVPD $scratch_dir/mvpd_fill.bin.ecc";
 $build_pnor_command .= " --binFile_DJVPD $scratch_dir/djvpd_fill.bin.ecc";

--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -168,10 +168,16 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (16MB)</description>
+        <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0x961000</physicalOffset>
-        <physicalRegionSize>0x1000000</physicalRegionSize>
+        <physicalOffset>0xA59000</physicalOffset>
+        <physicalRegionSize>0x100000</physicalRegionSize>
+        <side>A</side>
+    <section>
+        <description>Bootloader Kernel (15MB)</description>
+        <eyeCatch>BOOTKERNEL</eyeCatch>
+        <physicalOffset>0xB59000</physicalOffset>
+        <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>A</side>
     </section>
     <section>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -172,10 +172,17 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (16MB)</description>
+        <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0xCA9000</physicalOffset>
-        <physicalRegionSize>0x1000000</physicalRegionSize>
+        <physicalRegionSize>0x100000</physicalRegionSize>
+        <side>A</side>
+    </section>
+    <section>
+        <description>Bootloader Kernel (15MB)</description>
+        <eyeCatch>BOOTKERNEL</eyeCatch>
+        <physicalOffset>0xDA9000</physicalOffset>
+        <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>A</side>
     </section>
     <section>
@@ -316,10 +323,18 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (16MB)</description>
+        <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0x2C80000</physicalOffset>
-        <physicalRegionSize>0x1000000</physicalRegionSize>
+        <physicalRegionSize>0x100000</physicalRegionSize>
+        <side>B</side>
+        <readOnly/>
+    </section>
+    <section>
+        <description>Bootloader Kernel (15MB)</description>
+        <eyeCatch>BOOTKERNEL</eyeCatch>
+        <physicalOffset>0x2D80000</physicalOffset>
+        <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
     </section>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -171,10 +171,17 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (16MB)</description>
+        <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0xCA9000</physicalOffset>
-        <physicalRegionSize>0x1000000</physicalRegionSize>
+        <physicalRegionSize>0x100000</physicalRegionSize>
+        <side>A</side>
+    </section>
+    <section>
+        <description>Bootloader Kernel (15MB)</description>
+        <eyeCatch>BOOTKERNEL</eyeCatch>
+        <physicalOffset>0xDA9000</physicalOffset>
+        <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>A</side>
     </section>
     <section>
@@ -309,10 +316,17 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (16MB)</description>
+        <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0x2C80000</physicalOffset>
-        <physicalRegionSize>0x1000000</physicalRegionSize>
+        <physicalRegionSize>0x100000</physicalRegionSize>
+        <side>B</side>
+    </section>
+    <section>
+        <description>Bootloader Kernel (15MB)</description>
+        <eyeCatch>BOOTKERNEL</eyeCatch>
+        <physicalOffset>0x2D80000</physicalOffset>
+        <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>B</side>
     </section>
     <section>


### PR DESCRIPTION
The pnor will now contain a BOOTKERNEL partition, which holds the linux
kernel and initramfs that was previously placed in along with skiboot in
the PAYLOAD partition.

The PAYLOAD partition is shrunk to 1MB. Given skiboot is currently about
700KB, this should accommodate growth in the skiboot binary over time.
The remaining 15MB is used for the kernel and initramfs.

The name BOOTKERNEL is chosen to allow the addition of a BOOTFS in the
future, where the kernel and initramfs is separated.

Signed-off-by: Joel Stanley <joel@jms.id.au>