### PR TITLE
Changed the size of HBRT to 3MB+ECC and updated update_image.pl

### DIFF
--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -183,10 +183,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Runtime Services for Sapphire (3MB)</description>
+        <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
         <eyeCatch>HBRT</eyeCatch>
         <physicalOffset>0x19F1000</physicalOffset>
-        <physicalRegionSize>0x300000</physicalRegionSize>
+        <physicalRegionSize>0x360000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
         <ecc/>
@@ -194,24 +194,24 @@ Layout Description
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x1D29000</physicalOffset>
+        <physicalOffset>0x1D51000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
-        <side>A</side>
-        <ecc/>
-    </section>
-    <section>
-        <description>CAPP Lid (38K)</description>
-        <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x1E49000</physicalOffset>
-        <physicalRegionSize>0xB000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>
     <section>
         <description>FIRDATA (12K)</description>
         <eyeCatch>FIRDATA</eyeCatch>
-        <physicalOffset>0x1E54000</physicalOffset>
+        <physicalOffset>0x1E71000</physicalOffset>
         <physicalRegionSize>0x3000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
+    </section>
+    <section>
+        <description>CAPP Lid (38K)</description>
+        <eyeCatch>CAPP</eyeCatch>
+        <physicalOffset>0x1E74000</physicalOffset>
+        <physicalRegionSize>0xB000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -163,10 +163,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Runtime Services for Sapphire (3MB)</description>
+        <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
         <eyeCatch>HBRT</eyeCatch>
         <physicalOffset>0x949000</physicalOffset>
-        <physicalRegionSize>0x300000</physicalRegionSize>
+        <physicalRegionSize>0x360000</physicalRegionSize>
         <sha512Version/>
         <side>A</side>
         <ecc/>
@@ -174,14 +174,14 @@ Layout Description
     <section>
         <description>Payload (16MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0xC49000</physicalOffset>
+        <physicalOffset>0xCA9000</physicalOffset>
         <physicalRegionSize>0x1000000</physicalRegionSize>
         <side>A</side>
     </section>
     <section>
         <description>Temporary Attribute Override (32K)</description>
         <eyeCatch>ATTR_TMP</eyeCatch>
-        <physicalOffset>0x1C49000</physicalOffset>
+        <physicalOffset>0x1CA9000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -189,7 +189,7 @@ Layout Description
     <section>
         <description>Permanent Attribute Override (32K)</description>
         <eyeCatch>ATTR_PERM</eyeCatch>
-        <physicalOffset>0x1C51000</physicalOffset>
+        <physicalOffset>0x1CB1000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -197,7 +197,7 @@ Layout Description
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x1C59000</physicalOffset>
+        <physicalOffset>0x1CB9000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -205,7 +205,7 @@ Layout Description
     <section>
         <description>Special PNOR Test Space (36K)</description>
         <eyeCatch>TEST</eyeCatch>
-        <physicalOffset>0x1D79000</physicalOffset>
+        <physicalOffset>0x1DD9000</physicalOffset>
         <physicalRegionSize>0x9000</physicalRegionSize>
         <testonly/>
         <side>A</side>
@@ -214,7 +214,7 @@ Layout Description
     <section>
         <description>Nvram (576K)</description>
         <eyeCatch>NVRAM</eyeCatch>
-        <physicalOffset>0x1D82000</physicalOffset>
+        <physicalOffset>0x1DE2000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -222,7 +222,7 @@ Layout Description
     <section>
         <description>FIRDATA (12K)</description>
         <eyeCatch>FIRDATA</eyeCatch>
-        <physicalOffset>0x1E12000</physicalOffset>
+        <physicalOffset>0x1E72000</physicalOffset>
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -230,7 +230,7 @@ Layout Description
     <section>
         <description>Global Data (36K)</description>
         <eyeCatch>GLOBAL</eyeCatch>
-        <physicalOffset>0x1E15000</physicalOffset>
+        <physicalOffset>0x1E75000</physicalOffset>
         <physicalRegionSize>0x9000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -238,7 +238,7 @@ Layout Description
     <section>
         <description>CAPP Lid (38K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x1E1E000</physicalOffset>
+        <physicalOffset>0x1E7E000</physicalOffset>
         <physicalRegionSize>0xB000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -295,7 +295,7 @@ Layout Description
     <section>
         <description>Hostboot Extended image (5.625MB)</description>
         <eyeCatch>HBI</eyeCatch>
-        <physicalOffset>0x188000</physicalOffset>
+        <physicalOffset>0x2188000</physicalOffset>
         <physicalRegionSize>0x5A0000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
@@ -333,10 +333,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Runtime Services for Sapphire (3MB)</description>
+        <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
         <eyeCatch>HBRT</eyeCatch>
         <physicalOffset>0x2920000</physicalOffset>
-        <physicalRegionSize>0x300000</physicalRegionSize>
+        <physicalRegionSize>0x360000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
         <readOnly/>
@@ -345,7 +345,7 @@ Layout Description
     <section>
         <description>Payload (16MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0x2C20000</physicalOffset>
+        <physicalOffset>0x2C80000</physicalOffset>
         <physicalRegionSize>0x1000000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
@@ -353,7 +353,7 @@ Layout Description
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x3C20000</physicalOffset>
+        <physicalOffset>0x3C80000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
@@ -362,7 +362,7 @@ Layout Description
     <section>
         <description>CAPP Lid (38K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x3D40000</physicalOffset>
+        <physicalOffset>0x3DA0000</physicalOffset>
         <physicalRegionSize>0xB000</physicalRegionSize>
         <side>B</side>
         <readOnly/>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -162,10 +162,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Runtime Services for Sapphire (3MB)</description>
+        <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
         <eyeCatch>HBRT</eyeCatch>
         <physicalOffset>0x949000</physicalOffset>
-        <physicalRegionSize>0x300000</physicalRegionSize>
+        <physicalRegionSize>0x360000</physicalRegionSize>
         <sha512Version/>
         <side>A</side>
         <ecc/>
@@ -173,14 +173,14 @@ Layout Description
     <section>
         <description>Payload (16MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0xC49000</physicalOffset>
+        <physicalOffset>0xCA9000</physicalOffset>
         <physicalRegionSize>0x1000000</physicalRegionSize>
         <side>A</side>
     </section>
     <section>
         <description>Temporary Attribute Override (32K)</description>
         <eyeCatch>ATTR_TMP</eyeCatch>
-        <physicalOffset>0x1C49000</physicalOffset>
+        <physicalOffset>0x1CA9000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -188,7 +188,7 @@ Layout Description
     <section>
         <description>Permanent Attribute Override (32K)</description>
         <eyeCatch>ATTR_PERM</eyeCatch>
-        <physicalOffset>0x1C51000</physicalOffset>
+        <physicalOffset>0x1CB1000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -196,7 +196,7 @@ Layout Description
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x1C59000</physicalOffset>
+        <physicalOffset>0x1CB9000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -204,7 +204,7 @@ Layout Description
     <section>
         <description>Special PNOR Test Space (36K)</description>
         <eyeCatch>TEST</eyeCatch>
-        <physicalOffset>0x1D79000</physicalOffset>
+        <physicalOffset>0x1DD9000</physicalOffset>
         <physicalRegionSize>0x9000</physicalRegionSize>
         <testonly/>
         <side>A</side>
@@ -213,7 +213,7 @@ Layout Description
     <section>
         <description>Nvram (576K)</description>
         <eyeCatch>NVRAM</eyeCatch>
-        <physicalOffset>0x1D82000</physicalOffset>
+        <physicalOffset>0x1DE2000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -221,7 +221,7 @@ Layout Description
     <section>
         <description>FIRDATA (12K)</description>
         <eyeCatch>FIRDATA</eyeCatch>
-        <physicalOffset>0x1E12000</physicalOffset>
+        <physicalOffset>0x1E72000</physicalOffset>
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -229,7 +229,7 @@ Layout Description
     <section>
         <description>Global Data (36K)</description>
         <eyeCatch>GLOBAL</eyeCatch>
-        <physicalOffset>0x1E15000</physicalOffset>
+        <physicalOffset>0x1E75000</physicalOffset>
         <physicalRegionSize>0x9000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -237,7 +237,7 @@ Layout Description
     <section>
         <description>CAPP Lid (38K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x1E1E000</physicalOffset>
+        <physicalOffset>0x1E7E000</physicalOffset>
         <physicalRegionSize>0xB000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -293,7 +293,7 @@ Layout Description
     <section>
         <description>Hostboot Extended image (5.625MB)</description>
         <eyeCatch>HBI</eyeCatch>
-        <physicalOffset>0x188000</physicalOffset>
+        <physicalOffset>0x2188000</physicalOffset>
         <physicalRegionSize>0x5A0000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
@@ -327,10 +327,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Runtime Services for Sapphire (3MB)</description>
+        <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
         <eyeCatch>HBRT</eyeCatch>
         <physicalOffset>0x2920000</physicalOffset>
-        <physicalRegionSize>0x300000</physicalRegionSize>
+        <physicalRegionSize>0x360000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
         <ecc/>
@@ -338,14 +338,14 @@ Layout Description
     <section>
         <description>Payload (16MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0x2C20000</physicalOffset>
+        <physicalOffset>0x2C80000</physicalOffset>
         <physicalRegionSize>0x1000000</physicalRegionSize>
         <side>B</side>
     </section>
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x3C20000</physicalOffset>
+        <physicalOffset>0x3C80000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>B</side>
         <ecc/>
@@ -353,7 +353,7 @@ Layout Description
     <section>
         <description>CAPP Lid (38K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x3D40000</physicalOffset>
+        <physicalOffset>0x3DA0000</physicalOffset>
         <physicalRegionSize>0xB000</physicalRegionSize>
         <side>B</side>
         <ecc/>

--- a/update_image.pl
+++ b/update_image.pl
@@ -91,7 +91,7 @@ run_command("echo -en VERSION\\\\0 > $scratch_dir/hostboot_runtime.sha.bin");
 run_command("sha512sum $hb_image_dir/img/hostboot_runtime.bin | awk \'{print \$1}\' | xxd -pr -r >> $scratch_dir/hostboot_runtime.sha.bin");
 run_command("dd if=$scratch_dir/hostboot_runtime.sha.bin of=$scratch_dir/hostboot.temp.bin ibs=4k conv=sync");
 run_command("cat $hb_image_dir/img/hostboot_runtime.bin >> $scratch_dir/hostboot.temp.bin");
-run_command("dd if=$scratch_dir/hostboot.temp.bin of=$scratch_dir/hostboot_runtime.header.bin ibs=2048K conv=sync");
+run_command("dd if=$scratch_dir/hostboot.temp.bin of=$scratch_dir/hostboot_runtime.header.bin ibs=3072K conv=sync");
 run_command("ecc --inject $scratch_dir/hostboot_runtime.header.bin --output $scratch_dir/hostboot_runtime.header.bin.ecc --p8");
 
 run_command("echo -en VERSION\\\\0 > $scratch_dir/hostboot_extended.sha.bin");


### PR DESCRIPTION
Initially, we allocated a total of 3MB for HBRT. We needed to allocate 3MB+ECC. Additionally, update_image.pl needed to be updated as well  to support the bigger size. 