### PR TITLE
Add CAPI support

### DIFF
--- a/HabaneroPnorLayout.xml
+++ b/HabaneroPnorLayout.xml
@@ -179,10 +179,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>CAPP Lid(38K)</description>
+        <description>CAPP Lid(144K)</description>
         <eyeCatch>CAPP</eyeCatch>
         <physicalOffset>0x2428000</physicalOffset>
-        <physicalRegionSize>0xB000</physicalRegionSize>
+        <physicalRegionSize>0x24000</physicalRegionSize>
         <ecc/>
     </section>
     <section>

--- a/PalmettoPnorLayout.xml
+++ b/PalmettoPnorLayout.xml
@@ -200,10 +200,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>CAPP Lid (38K)</description>
+        <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
         <physicalOffset>0x1E4C000</physicalOffset>
-        <physicalRegionSize>0xB000</physicalRegionSize>
+        <physicalRegionSize>0x24000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>

--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -104,7 +104,7 @@ $build_pnor_command .= " --binFile_ATTR_TMP $scratch_dir/attr_tmp.bin.ecc";
 $build_pnor_command .= " --binFile_ATTR_PERM $scratch_dir/attr_perm.bin.ecc";
 $build_pnor_command .= " --binFile_OCC $occ_binary_filename.ecc";
 $build_pnor_command .= " --binFile_FIRDATA $scratch_dir/firdata.bin.ecc";
-$build_pnor_command .= " --binFile_CAPP $scratch_dir/capp.bin.ecc";
+$build_pnor_command .= " --binFile_CAPP $scratch_dir/cappucode.bin.ecc";
 $build_pnor_command .= " --fpartCmd \"fpart\"";
 $build_pnor_command .= " --fcpCmd \"fcp\"";
 print "###############################";

--- a/update_image.pl
+++ b/update_image.pl
@@ -14,6 +14,7 @@ my $targeting_binary_source = "";
 my $sbe_binary_filename = "";
 my $sbec_binary_filename = "";
 my $occ_binary_filename = "";
+my $capp_binary_filename = "";
 
 while (@ARGV > 0){
     $_ = $ARGV[0];
@@ -59,7 +60,10 @@ while (@ARGV > 0){
         $occ_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
         shift;
     }
-    else {
+    elsif (/^-capp_binary_filename/i){
+        $capp_binary_filename = $ARGV[1] or die "Bad command line arg given: execting a config type.\n";
+        shift;
+    }    else {
         print "Unrecognized command line arg: $_ \n";
         #print "To view all the options and help text run \'$program_name -h\' \n";
         exit 1;
@@ -136,6 +140,10 @@ run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/a
 #Create blank binary file for OCC Partition
 run_command("dd if=$occ_binary_filename of=$scratch_dir/hostboot.temp.bin ibs=1M conv=sync");
 run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $occ_binary_filename.ecc --p8");
+
+#Encode Ecc into CAPP Partition
+run_command("dd if=$capp_binary_filename bs=144K count=1 > $scratch_dir/hostboot.temp.bin");
+run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/cappucode.bin.ecc --p8");
 
 #Create blank binary file for FIRDATA Partition
 run_command("dd if=/dev/zero bs=8K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");

--- a/update_image.pl
+++ b/update_image.pl
@@ -142,7 +142,7 @@ run_command("dd if=/dev/zero bs=8K count=1 | tr \"\\000\" \"\\377\" > $scratch_d
 run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/firdata.bin.ecc --p8");
 
 #Create blank binary file for CAPP Partition
-run_command("dd if=/dev/zero bs=38K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
+run_command("dd if=/dev/zero bs=144K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
 run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/capp.bin.ecc --p8");
 
 #Copy Binary Data files for consistency


### PR DESCRIPTION
Patrick,

This adds CAPI support to pnor. It's not based on the most recent pnor tree as (as discussed offline) it doesn't work with the latest op-build. 

I've posted the code to add ECC to skiboot so hopefully that'll be included soon.

Mikey