### PR TITLE
Adding XZ decompression functionality for the skiboot payload

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -18,6 +18,7 @@ my $sbe_binary_filename = "";
 my $wink_binary_filename = "";
 my $occ_binary_filename = "";
 my $openpower_version_filename = "";
+my $xz_compression = "false";
 
 while (@ARGV > 0){
     $_ = $ARGV[0];
@@ -84,6 +85,10 @@ while (@ARGV > 0){
         $openpower_version_filename = $ARGV[1] or die "Bad command line arg given: expecting openpower version filename.\n";
         shift;
     }
+    elsif (/^-xz_compression/i){
+        $xz_compression = $ARGV[1] or die "Bad command line arg given: expection xz compression flag.\n";
+        shift;
+    }
     else {
         print "Unrecognized command line arg: $_ \n";
         print "To view all the options and help text run \'$program_name -h\' \n";
@@ -98,6 +103,11 @@ if ($outdir eq "") {
 
 print "scratch_dir = $scratch_dir\n";
 print "pnor_data_dir = $pnor_data_dir\n";
+
+if($xz_compression eq "false") {
+    run_command("sed -i '/compressed/d'  $xml_layout_file\n");
+    run_command("sed -i '/algorithm/d' $xml_layout_file\n");
+}
 
 my $build_pnor_command = "$hb_image_dir/buildpnor.pl";
 $build_pnor_command .= " --pnorOutBin $pnor_filename --pnorLayout $xml_layout_file";

--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -182,6 +182,10 @@ Layout Description
         <physicalOffset>0x961000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
+        <compressed>
+            <algorithm>xz</algorithm>
+            <uncompressedSize>0x100000</uncompressedSize>
+        </compressed>
     </section>
     <section>
         <description>Bootloader Kernel (15MB)</description>

--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -170,14 +170,14 @@ Layout Description
     <section>
         <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0xA59000</physicalOffset>
+        <physicalOffset>0x961000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
     </section>
     <section>
         <description>Bootloader Kernel (15MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0xB59000</physicalOffset>
+        <physicalOffset>0xA61000</physicalOffset>
         <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>A</side>
     </section>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -184,6 +184,10 @@ Layout Description
         <physicalOffset>0xCA9000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
+        <compressed>
+            <algorithm>xz</algorithm>
+            <uncompressedSize>0x100000</uncompressedSize>
+        </compressed>
     </section>
     <section>
         <description>Bootloader Kernel (15MB)</description>
@@ -339,6 +343,10 @@ Layout Description
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
+        <compressed>
+            <algorithm>xz</algorithm>
+            <uncompressedSize>0x100000</uncompressedSize>
+        </compressed>
     </section>
     <section>
         <description>Bootloader Kernel (15MB)</description>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -183,6 +183,10 @@ Layout Description
         <physicalOffset>0xCA9000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
+        <compressed>
+            <algorithm>xz</algorithm>
+            <uncompressedSize>0x100000</uncompressedSize>
+        </compressed>
     </section>
     <section>
         <description>Bootloader Kernel (15MB)</description>
@@ -331,6 +335,10 @@ Layout Description
         <physicalOffset>0x2C80000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>B</side>
+        <compressed>
+            <algorithm>xz</algorithm>
+            <uncompressedSize>0x100000</uncompressedSize>
+        </compressed>
     </section>
     <section>
         <description>Bootloader Kernel (15MB)</description>

--- a/update_image.pl
+++ b/update_image.pl
@@ -17,6 +17,7 @@ my $wink_binary_filename = "";
 my $occ_binary_filename = "";
 my $capp_binary_filename = "";
 my $openpower_version_filename = "";
+my $payload = "";
 
 while (@ARGV > 0){
     $_ = $ARGV[0];
@@ -74,6 +75,10 @@ while (@ARGV > 0){
         $openpower_version_filename = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
         shift;
     }
+    elsif (/^-payload/i){
+        $payload = $ARGV[1] or die "Bad command line arg given: expecting a filepath to payload binary file.\n";
+        shift;
+    }
     else {
         print "Unrecognized command line arg: $_ \n";
         #print "To view all the options and help text run \'$program_name -h\' \n";
@@ -81,6 +86,9 @@ while (@ARGV > 0){
     }
     shift;
 }
+
+# Compress the skiboot lid image with lzma
+run_command("xz -fk --check=crc32 $payload");
 
 # Pad Targeting binary to 4k page size, then add ECC data
 ###


### PR DESCRIPTION
This is the functionality for RTC 125550.  Currently, the default is to have the skiboot payload not be decompressed. This is all configured with a config variable. This needs to be merged with two other commits:
1) Hostboot-side: Change-Id Iea8bf169a1e9f81419effe66f147148c68d33131,  http://gfw160.aus.stglabs.ibm.com:8080/gerrit/#/c/19457/ 
2) op-build pull request with the same comment "Adding XZ decompression functionality for the skiboot payload" (not created yet)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/34)
<!-- Reviewable:end -->
