### PR TITLE
Move section layouts to add more space to HBI section

### DIFF
--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -70,10 +70,10 @@ Layout Description
         </side>
     </metadata>
     <section>
-        <description>Hostboot Extended image (5.625MB)</description>
+        <description>Hostboot Extended image (6.18MB)</description>
         <eyeCatch>HBI</eyeCatch>
         <physicalOffset>0x10000</physicalOffset>
-        <physicalRegionSize>0x5A0000</physicalRegionSize>
+        <physicalRegionSize>0x630000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
         <ecc/>
@@ -81,7 +81,7 @@ Layout Description
     <section>
         <description>Module VPD (576K)</description>
         <eyeCatch>MVPD</eyeCatch>
-        <physicalOffset>0x5B0000</physicalOffset>
+        <physicalOffset>0x67F000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -90,7 +90,7 @@ Layout Description
     <section>
         <description>Centaur VPD (288K)</description>
         <eyeCatch>CVPD</eyeCatch>
-        <physicalOffset>0x640000</physicalOffset>
+        <physicalOffset>0x70F000</physicalOffset>
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -99,7 +99,7 @@ Layout Description
     <section>
         <description>DIMM JEDEC (288K)</description>
         <eyeCatch>DJVPD</eyeCatch>
-        <physicalOffset>0x688000</physicalOffset>
+        <physicalOffset>0x757000</physicalOffset>
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -108,7 +108,7 @@ Layout Description
     <section>
         <description>Hostboot Data (0.375M)</description>
         <eyeCatch>HBD</eyeCatch>
-        <physicalOffset>0x6D0000</physicalOffset>
+        <physicalOffset>0x79F000</physicalOffset>
         <physicalRegionSize>0x60000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -116,7 +116,7 @@ Layout Description
     <section>
         <description>Centaur SBE (576K)</description>
         <eyeCatch>SBEC</eyeCatch>
-        <physicalOffset>0x730000</physicalOffset>
+        <physicalOffset>0x7FF000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>A</side>
         <sha512perEC/>
@@ -125,7 +125,7 @@ Layout Description
     <section>
         <description>SBE-IPL (Staging Area) (288K)</description>
         <eyeCatch>SBE</eyeCatch>
-        <physicalOffset>0x7C0000</physicalOffset>
+        <physicalOffset>0x88F000</physicalOffset>
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>A</side>
         <sha512perEC/>
@@ -134,7 +134,7 @@ Layout Description
     <section>
         <description>Temporary Attribute Override (32K)</description>
         <eyeCatch>ATTR_TMP</eyeCatch>
-        <physicalOffset>0x808000</physicalOffset>
+        <physicalOffset>0x8D7000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>A</side>
         <reprovision/>
@@ -142,7 +142,7 @@ Layout Description
     <section>
         <description>Permanent Attribute Override (32K)</description>
         <eyeCatch>ATTR_PERM</eyeCatch>
-        <physicalOffset>0x810000</physicalOffset>
+        <physicalOffset>0x8DF000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -151,7 +151,7 @@ Layout Description
     <section>
         <description>Sleep Winkle Ref Image (1.125MB)</description>
         <eyeCatch>WINK</eyeCatch>
-        <physicalOffset>0x818000</physicalOffset>
+        <physicalOffset>0x8E7000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -160,7 +160,7 @@ Layout Description
     <section>
         <description>Guard Data (20K)</description>
         <eyeCatch>GUARD</eyeCatch>
-        <physicalOffset>0x938000</physicalOffset>
+        <physicalOffset>0xA07000</physicalOffset>
         <physicalRegionSize>0x5000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -170,7 +170,7 @@ Layout Description
     <section>
         <description>Hostboot Error Logs (144K)</description>
         <eyeCatch>HBEL</eyeCatch>
-        <physicalOffset>0x93D000</physicalOffset>
+        <physicalOffset>0xA0C000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -179,21 +179,21 @@ Layout Description
     <section>
         <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0x961000</physicalOffset>
+        <physicalOffset>0xA30000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
     </section>
     <section>
         <description>Bootloader Kernel (15MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0xA61000</physicalOffset>
+        <physicalOffset>0xB30000</physicalOffset>
         <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>A</side>
     </section>
     <section>
         <description>Nvram (576K)</description>
         <eyeCatch>NVRAM</eyeCatch>
-        <physicalOffset>0x1961000</physicalOffset>
+        <physicalOffset>0x1A30000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -203,7 +203,7 @@ Layout Description
     <section>
         <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
         <eyeCatch>HBRT</eyeCatch>
-        <physicalOffset>0x19F1000</physicalOffset>
+        <physicalOffset>0x1AC0000</physicalOffset>
         <physicalRegionSize>0x360000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -212,7 +212,7 @@ Layout Description
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x1D51000</physicalOffset>
+        <physicalOffset>0x1E20000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -220,7 +220,7 @@ Layout Description
     <section>
         <description>FIRDATA (12K)</description>
         <eyeCatch>FIRDATA</eyeCatch>
-        <physicalOffset>0x1E71000</physicalOffset>
+        <physicalOffset>0x1F40000</physicalOffset>
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -229,7 +229,7 @@ Layout Description
     <section>
         <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x1E74000</physicalOffset>
+        <physicalOffset>0x1F43000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>A</side>
         <ecc/>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -134,20 +134,11 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Hostboot Extended image (5.625MB)</description>
+        <description>Hostboot Extended image (6.18MB)</description>
         <eyeCatch>HBI</eyeCatch>
         <physicalOffset>0x1B1000</physicalOffset>
-        <physicalRegionSize>0x5A0000</physicalRegionSize>
+        <physicalRegionSize>0x630000</physicalRegionSize>
         <sha512Version/>
-        <side>A</side>
-        <ecc/>
-    </section>
-    <section>
-        <description>Centaur SBE (576K)</description>
-        <eyeCatch>SBEC</eyeCatch>
-        <physicalOffset>0x751000</physicalOffset>
-        <physicalRegionSize>0x90000</physicalRegionSize>
-        <sha512perEC/>
         <side>A</side>
         <ecc/>
     </section>
@@ -210,9 +201,18 @@ Layout Description
         <reprovision/>
     </section>
     <section>
+        <description>Centaur SBE (576K)</description>
+        <eyeCatch>SBEC</eyeCatch>
+        <physicalOffset>0x1CF0000</physicalOffset>
+        <physicalRegionSize>0x90000</physicalRegionSize>
+        <sha512perEC/>
+        <side>A</side>
+        <ecc/>
+    </section>
+    <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x1CB9000</physicalOffset>
+        <physicalOffset>0x1D80000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -220,7 +220,7 @@ Layout Description
     <section>
         <description>Special PNOR Test Space (36K)</description>
         <eyeCatch>TEST</eyeCatch>
-        <physicalOffset>0x1DD9000</physicalOffset>
+        <physicalOffset>0x1EA0000</physicalOffset>
         <physicalRegionSize>0x9000</physicalRegionSize>
         <testonly/>
         <side>A</side>
@@ -229,7 +229,7 @@ Layout Description
     <section>
         <description>Nvram (576K)</description>
         <eyeCatch>NVRAM</eyeCatch>
-        <physicalOffset>0x1DE2000</physicalOffset>
+        <physicalOffset>0x1EA9000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -239,7 +239,7 @@ Layout Description
     <section>
         <description>FIRDATA (12K)</description>
         <eyeCatch>FIRDATA</eyeCatch>
-        <physicalOffset>0x1E72000</physicalOffset>
+        <physicalOffset>0x1F39000</physicalOffset>
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -248,7 +248,7 @@ Layout Description
     <section>
         <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x1E7E000</physicalOffset>
+        <physicalOffset>0x1F3C000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -283,10 +283,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Extended image (5.625MB)</description>
+        <description>Hostboot Extended image (6.18MB)</description>
         <eyeCatch>HBI</eyeCatch>
         <physicalOffset>0x2188000</physicalOffset>
-        <physicalRegionSize>0x5A0000</physicalRegionSize>
+        <physicalRegionSize>0x630000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
         <readOnly/>
@@ -295,7 +295,7 @@ Layout Description
     <section>
         <description>Centaur SBE (576K)</description>
         <eyeCatch>SBEC</eyeCatch>
-        <physicalOffset>0x2728000</physicalOffset>
+        <physicalOffset>0x28CB000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <sha512perEC/>
         <side>B</side>
@@ -305,7 +305,7 @@ Layout Description
     <section>
         <description>SBE-IPL (Staging Area) (288K)</description>
         <eyeCatch>SBE</eyeCatch>
-        <physicalOffset>0x27B8000</physicalOffset>
+        <physicalOffset>0x295B000</physicalOffset>
         <physicalRegionSize>0x48000</physicalRegionSize>
         <sha512perEC/>
         <side>B</side>
@@ -315,7 +315,7 @@ Layout Description
     <section>
         <description>Sleep Winkle Ref Image (1.125MB)</description>
         <eyeCatch>WINK</eyeCatch>
-        <physicalOffset>0x2800000</physicalOffset>
+        <physicalOffset>0x29A3000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
@@ -325,7 +325,7 @@ Layout Description
     <section>
         <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
         <eyeCatch>HBRT</eyeCatch>
-        <physicalOffset>0x2920000</physicalOffset>
+        <physicalOffset>0x2AC3000</physicalOffset>
         <physicalRegionSize>0x360000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
@@ -335,7 +335,7 @@ Layout Description
     <section>
         <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0x2C80000</physicalOffset>
+        <physicalOffset>0x2E23000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
@@ -343,7 +343,7 @@ Layout Description
     <section>
         <description>Bootloader Kernel (15MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0x2D80000</physicalOffset>
+        <physicalOffset>0x2F23000</physicalOffset>
         <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
@@ -351,7 +351,7 @@ Layout Description
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x3C80000</physicalOffset>
+        <physicalOffset>0x3E23000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
@@ -360,7 +360,7 @@ Layout Description
     <section>
         <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x3DA0000</physicalOffset>
+        <physicalOffset>0x3F43000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>B</side>
         <readOnly/>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -133,20 +133,11 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Hostboot Extended image (5.625MB)</description>
+        <description>Hostboot Extended image (6.18MB)</description>
         <eyeCatch>HBI</eyeCatch>
         <physicalOffset>0x1B1000</physicalOffset>
-        <physicalRegionSize>0x5A0000</physicalRegionSize>
+        <physicalRegionSize>0x630000</physicalRegionSize>
         <sha512Version/>
-        <side>A</side>
-        <ecc/>
-    </section>
-    <section>
-        <description>Centaur SBE (576K)</description>
-        <eyeCatch>SBEC</eyeCatch>
-        <physicalOffset>0x751000</physicalOffset>
-        <physicalRegionSize>0x90000</physicalRegionSize>
-        <sha512perEC/>
         <side>A</side>
         <ecc/>
     </section>
@@ -209,9 +200,18 @@ Layout Description
         <reprovision/>
     </section>
     <section>
+        <description>Centaur SBE (576K)</description>
+        <eyeCatch>SBEC</eyeCatch>
+        <physicalOffset>0x1CF0000</physicalOffset>
+        <physicalRegionSize>0x90000</physicalRegionSize>
+        <sha512perEC/>
+        <side>A</side>
+        <ecc/>
+    </section>
+    <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x1CB9000</physicalOffset>
+        <physicalOffset>0x1D80000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -219,7 +219,7 @@ Layout Description
     <section>
         <description>Special PNOR Test Space (36K)</description>
         <eyeCatch>TEST</eyeCatch>
-        <physicalOffset>0x1DD9000</physicalOffset>
+        <physicalOffset>0x1EA0000</physicalOffset>
         <physicalRegionSize>0x9000</physicalRegionSize>
         <testonly/>
         <side>A</side>
@@ -228,7 +228,7 @@ Layout Description
     <section>
         <description>Nvram (576K)</description>
         <eyeCatch>NVRAM</eyeCatch>
-        <physicalOffset>0x1DE2000</physicalOffset>
+        <physicalOffset>0x1EA9000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>sideless</side>
         <preserved/>
@@ -238,7 +238,7 @@ Layout Description
     <section>
         <description>FIRDATA (12K)</description>
         <eyeCatch>FIRDATA</eyeCatch>
-        <physicalOffset>0x1E72000</physicalOffset>
+        <physicalOffset>0x1F39000</physicalOffset>
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -247,7 +247,7 @@ Layout Description
     <section>
         <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x1E7E000</physicalOffset>
+        <physicalOffset>0x1F3C000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>A</side>
         <ecc/>
@@ -281,10 +281,10 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Extended image (5.625MB)</description>
+        <description>Hostboot Extended image (6.18MB)</description>
         <eyeCatch>HBI</eyeCatch>
         <physicalOffset>0x2188000</physicalOffset>
-        <physicalRegionSize>0x5A0000</physicalRegionSize>
+        <physicalRegionSize>0x630000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
         <ecc/>
@@ -292,7 +292,7 @@ Layout Description
     <section>
         <description>Centaur SBE (576K)</description>
         <eyeCatch>SBEC</eyeCatch>
-        <physicalOffset>0x2728000</physicalOffset>
+        <physicalOffset>0x28CB000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <sha512perEC/>
         <side>B</side>
@@ -301,7 +301,7 @@ Layout Description
     <section>
         <description>SBE-IPL (Staging Area) (288K)</description>
         <eyeCatch>SBE</eyeCatch>
-        <physicalOffset>0x27B8000</physicalOffset>
+        <physicalOffset>0x295B000</physicalOffset>
         <physicalRegionSize>0x48000</physicalRegionSize>
         <sha512perEC/>
         <side>B</side>
@@ -310,7 +310,7 @@ Layout Description
     <section>
         <description>Sleep Winkle Ref Image (1.125MB)</description>
         <eyeCatch>WINK</eyeCatch>
-        <physicalOffset>0x2800000</physicalOffset>
+        <physicalOffset>0x29A3000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
@@ -319,7 +319,7 @@ Layout Description
     <section>
         <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
         <eyeCatch>HBRT</eyeCatch>
-        <physicalOffset>0x2920000</physicalOffset>
+        <physicalOffset>0x2AC3000</physicalOffset>
         <physicalRegionSize>0x360000</physicalRegionSize>
         <sha512Version/>
         <side>B</side>
@@ -328,21 +328,21 @@ Layout Description
     <section>
         <description>Payload (1MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0x2C80000</physicalOffset>
+        <physicalOffset>0x2E23000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>B</side>
     </section>
     <section>
         <description>Bootloader Kernel (15MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0x2D80000</physicalOffset>
+        <physicalOffset>0x2F23000</physicalOffset>
         <physicalRegionSize>0xF00000</physicalRegionSize>
         <side>B</side>
     </section>
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x3C80000</physicalOffset>
+        <physicalOffset>0x3E23000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>B</side>
         <ecc/>
@@ -350,7 +350,7 @@ Layout Description
     <section>
         <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x3DA0000</physicalOffset>
+        <physicalOffset>0x3F43000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>B</side>
         <ecc/>

--- a/update_image.pl
+++ b/update_image.pl
@@ -113,7 +113,7 @@ run_command("env echo -en VERSION\\\\0 > $scratch_dir/hostboot_extended.sha.bin"
 run_command("sha512sum $hb_image_dir/img/hostboot_extended.bin | awk \'{print \$1}\' | xxd -pr -r >> $scratch_dir/hostboot_extended.sha.bin");
 run_command("dd if=$scratch_dir/hostboot_extended.sha.bin of=$scratch_dir/hostboot.temp.bin ibs=4k conv=sync");
 run_command("cat $hb_image_dir/img/hostboot_extended.bin >> $scratch_dir/hostboot.temp.bin");
-run_command("dd if=$scratch_dir/hostboot.temp.bin of=$scratch_dir/hostboot_extended.header.bin ibs=5120k conv=sync");
+run_command("dd if=$scratch_dir/hostboot.temp.bin of=$scratch_dir/hostboot_extended.header.bin ibs=5632k conv=sync");
 run_command("ecc --inject $scratch_dir/hostboot_extended.header.bin --output $scratch_dir/hostboot_extended.header.bin.ecc --p8");
 
 #Create blank binary file for HB Errorlogs (HBEL) Partition


### PR DESCRIPTION
I was able to move around sections to add gapped space to the HBI section. HBI increased by .775 MB. No other section sizes were changed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/36)

<!-- Reviewable:end -->
