### PR TITLE
Add secure boot partition to pnor.

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -121,6 +121,7 @@ $build_pnor_command .= " --binFile_ATTR_PERM $scratch_dir/attr_perm.bin.ecc";
 $build_pnor_command .= " --binFile_OCC $occ_binary_filename.ecc";
 $build_pnor_command .= " --binFile_FIRDATA $scratch_dir/firdata.bin.ecc";
 $build_pnor_command .= " --binFile_CAPP $scratch_dir/cappucode.bin.ecc";
+$build_pnor_command .= " --binFile_SECBOOT $scratch_dir/secboot.bin.ecc";
 $build_pnor_command .= " --binFile_VERSION $openpower_version_filename";
 $build_pnor_command .= " --fpartCmd \"fpart\"";
 $build_pnor_command .= " --fcpCmd \"fcp\"";

--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -224,6 +224,15 @@ Layout Description
         <ecc/>
     </section>
     <section>
+        <description>Secure Boot (144K)</description>
+        <eyeCatch>SECBOOT</eyeCatch>
+        <physicalOffset>0x1E98000</physicalOffset>
+        <physicalRegionSize>0x23280</physicalRegionSize>
+        <side>sideless</side>
+        <ecc/>
+        <preserved/>
+    </section>
+    <section>
         <description>Hostboot Base (576K)</description>
         <eyeCatch>HBB</eyeCatch>
         <physicalOffset>0x1F67000</physicalOffset>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -243,6 +243,15 @@ Layout Description
         <ecc/>
     </section>
     <section>
+        <description>Secure Boot (144K)</description>
+        <eyeCatch>SECBOOT</eyeCatch>
+        <physicalOffset>0x1E98000</physicalOffset>
+        <physicalRegionSize>0x23280</physicalRegionSize>
+        <side>sideless</side>
+        <ecc/>
+        <preserved/>
+    </section>
+    <section>
         <description>Hostboot Base (576K)</description>
         <!--NOTE: MUST update standalone.simics if offset changes -->
         <!--NOTE: HBB Address must be at pnorSize - 0x99000 for a new

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -242,6 +242,15 @@ Layout Description
         <ecc/>
     </section>
     <section>
+        <description>Secure Boot (144K)</description>
+        <eyeCatch>SECBOOT</eyeCatch>
+        <physicalOffset>0x1E98000</physicalOffset>
+        <physicalRegionSize>0x23280</physicalRegionSize>
+        <side>sideless</side>
+        <ecc/>
+        <preserved/>
+    </section>
+    <section>
         <description>Hostboot Base (576K)</description>
         <!--NOTE: MUST update standalone.simics if offset changes -->
         <!--NOTE: HBB Address must be at pnorSize - 0x99000 for a new

--- a/update_image.pl
+++ b/update_image.pl
@@ -160,6 +160,10 @@ run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/c
 run_command("dd if=/dev/zero bs=8K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
 run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/firdata.bin.ecc --p8");
 
+#Create blank binary file for SECBOOT Partition
+run_command("dd if=/dev/zero bs=128K count=1" > $scratch_dir/hostboot.temp.bin");
+run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/secboot.bin.ecc --p8");
+
 #Add openpower version file
 run_command("dd if=$openpower_version_filename of=$scratch_dir/openpower_version.temp ibs=4K conv=sync");
 run_command("cp $scratch_dir/openpower_version.temp $openpower_version_filename");


### PR DESCRIPTION
This adds a SECBOOT partition to the pnor that will contain a secure boot keystore. The partition is 144K, ECC-protected, sideless, and should be preserved across updates. The bootloader, i.e., Petitboot, will manage the contents of this partition.