### PR TITLE
Tag PNOR partitions to be erased during a system reprovision

### DIFF
--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -55,6 +55,8 @@ Layout Description
                    within the Partition.
     <preserved/>   Indicates Partition is preserved
                    across code updates.
+    <reprovision/> Indicates Partition should be erased
+                   during a system reprovision.
 -->
 
 <pnor>
@@ -158,6 +160,7 @@ Layout Description
         <side>A</side>
         <ecc/>
         <preserved/>
+        <reprovision/>
     </section>
     <section>
         <description>Hostboot Error Logs (144K)</description>
@@ -166,6 +169,7 @@ Layout Description
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>A</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Payload (1MB)</description>
@@ -189,6 +193,7 @@ Layout Description
         <side>A</side>
         <ecc/>
         <preserved/>
+        <reprovision/>
     </section>
     <section>
         <description>Hostboot Runtime Services for Sapphire (3.375MB)</description>
@@ -214,6 +219,7 @@ Layout Description
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>A</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>CAPP Lid (144K)</description>

--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -85,6 +85,7 @@ Layout Description
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>A</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Centaur VPD (288K)</description>
@@ -93,6 +94,7 @@ Layout Description
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>A</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>DIMM JEDEC (288K)</description>
@@ -101,6 +103,7 @@ Layout Description
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>A</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Hostboot Data (0.375M)</description>
@@ -134,6 +137,7 @@ Layout Description
         <physicalOffset>0x808000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>A</side>
+        <reprovision/>
     </section>
     <section>
         <description>Permanent Attribute Override (32K)</description>
@@ -142,6 +146,7 @@ Layout Description
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>A</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Sleep Winkle Ref Image (1.125MB)</description>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -111,6 +111,7 @@ Layout Description
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Module VPD (576K)</description>
@@ -120,6 +121,7 @@ Layout Description
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Centaur VPD (288K)</description>
@@ -129,6 +131,7 @@ Layout Description
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Hostboot Extended image (5.625MB)</description>
@@ -195,6 +198,7 @@ Layout Description
         <physicalOffset>0x1CA9000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
+        <reprovision/>
     </section>
     <section>
         <description>Permanent Attribute Override (32K)</description>
@@ -203,6 +207,7 @@ Layout Description
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>OCC Lid (1.125M)</description>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -55,6 +55,8 @@ Layout Description
     <sha512perEC/>  -> Indicates SHA512 is used to indicate version for each
                        EC-specific image within the Partition.
     <preserved/>    -> Indicates Partition is preserved across code updates.
+    <reprovision/>  -> Indicates Partition should be erased during a system 
+                       reprovision.
 </section>
 -->
 
@@ -81,6 +83,7 @@ Layout Description
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Guard Data (20K)</description>
@@ -90,6 +93,7 @@ Layout Description
         <side>A</side>
         <preserved/>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Hostboot Data (.375M)</description>
@@ -225,6 +229,7 @@ Layout Description
         <side>sideless</side>
         <ecc/>
         <preserved/>
+        <reprovision/>
     </section>
     <section>
         <description>FIRDATA (12K)</description>
@@ -233,6 +238,7 @@ Layout Description
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>CAPP Lid (144K)</description>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -55,6 +55,8 @@ Layout Description
     <sha512perEC/>  -> Indicates SHA512 is used to indicate version for each
                        EC-specific image within the Partition.
     <preserved/>    -> Indicates Partition is preserved across code updates.
+    <reprovision/>  -> Indicates Partition should be erased during a system 
+                       reprovision.
 </section>
 -->
 
@@ -80,6 +82,7 @@ Layout Description
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Guard Data (20K)</description>
@@ -89,6 +92,7 @@ Layout Description
         <side>A</side>
         <preserved/>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Hostboot Data (.375M)</description>
@@ -224,6 +228,7 @@ Layout Description
         <side>sideless</side>
         <preserved/>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>FIRDATA (12K)</description>
@@ -232,6 +237,7 @@ Layout Description
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>CAPP Lid (144K)</description>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -110,6 +110,7 @@ Layout Description
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Module VPD (576K)</description>
@@ -119,6 +120,7 @@ Layout Description
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Centaur VPD (288K)</description>
@@ -128,6 +130,7 @@ Layout Description
         <physicalRegionSize>0x48000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>Hostboot Extended image (5.625MB)</description>
@@ -194,6 +197,7 @@ Layout Description
         <physicalOffset>0x1CA9000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
+        <reprovision/>
     </section>
     <section>
         <description>Permanent Attribute Override (32K)</description>
@@ -202,6 +206,7 @@ Layout Description
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
+        <reprovision/>
     </section>
     <section>
         <description>OCC Lid (1.125M)</description>


### PR DESCRIPTION
There is also a buildpnor.pl change coming to set a bit in the TOC when this element is encountered.  Then, when the BMC receives a reprovision command, it will traverse the TOC to find partitions to erase.