### PR TITLE
NVRAM partition doesn't use ECC

### DIFF
--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -196,7 +196,6 @@ Layout Description
         <physicalOffset>0x1961000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>A</side>
-        <ecc/>
         <preserved/>
         <reprovision/>
     </section>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -232,7 +232,6 @@ Layout Description
         <physicalOffset>0x1DE2000</physicalOffset>
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>sideless</side>
-        <ecc/>
         <preserved/>
         <reprovision/>
     </section>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -232,7 +232,6 @@ Layout Description
         <physicalRegionSize>0x90000</physicalRegionSize>
         <side>sideless</side>
         <preserved/>
-        <ecc/>
         <reprovision/>
     </section>
     <section>


### PR DESCRIPTION
OPAL doesn't use ECC for the NVRAM partition, so remove the ecc flag
from the PNOR definitions.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/39)
<!-- Reviewable:end -->
