### PR TITLE
Add BMC_INV section to pass inventory info to Hostboot

### DIFF
--- a/defaultPnorLayoutSingleSide.xml
+++ b/defaultPnorLayoutSingleSide.xml
@@ -243,6 +243,14 @@ Layout Description
         <preserved/>
     </section>
     <section>
+        <description>BMC_INV (36K)</description>
+        <eyeCatch>BMC_INV</eyeCatch>
+        <physicalOffset>0x1EBC000</physicalOffset>
+        <physicalRegionSize>0x9000</physicalRegionSize>
+        <side>sideless</side>
+        <reprovision/>
+    </section>
+    <section>
         <description>Hostboot Base (576K)</description>
         <eyeCatch>HBB</eyeCatch>
         <physicalOffset>0x1F67000</physicalOffset>

--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -245,6 +245,14 @@ Layout Description
         <reprovision/>
     </section>
     <section>
+        <description>BMC_INV (36K)</description>
+        <eyeCatch>BMC_INV</eyeCatch>
+        <physicalOffset>0x1E75000</physicalOffset>
+        <physicalRegionSize>0x9000</physicalRegionSize>
+        <side>sideless</side>
+        <reprovision/>
+    </section>
+    <section>
         <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
         <physicalOffset>0x1E7E000</physicalOffset>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -244,6 +244,14 @@ Layout Description
         <reprovision/>
     </section>
     <section>
+        <description>BMC_INV (36K)</description>
+        <eyeCatch>BMC_INV</eyeCatch>
+        <physicalOffset>0x1E75000</physicalOffset>
+        <physicalRegionSize>0x9000</physicalRegionSize>
+        <side>sideless</side>
+        <reprovision/>
+    </section>
+    <section>
         <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
         <physicalOffset>0x1E7E000</physicalOffset>


### PR DESCRIPTION
Create a new BMC_INV (36KB) PNOR partition to allow the BMC to pass inventory information in the form of a flattened device tree that can be included in the Host device tree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/44)
<!-- Reviewable:end -->
