### PR TITLE
Fix golden side PNOR offsets for secboot section

### DIFF
--- a/defaultPnorLayoutWithGoldenSide.xml
+++ b/defaultPnorLayoutWithGoldenSide.xml
@@ -260,7 +260,7 @@ Layout Description
     <section>
         <description>Secure Boot (144K)</description>
         <eyeCatch>SECBOOT</eyeCatch>
-        <physicalOffset>0x1E98000</physicalOffset>
+        <physicalOffset>0x1EA2000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>

--- a/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/defaultPnorLayoutWithoutGoldenSide.xml
@@ -259,7 +259,7 @@ Layout Description
     <section>
         <description>Secure Boot (144K)</description>
         <eyeCatch>SECBOOT</eyeCatch>
-        <physicalOffset>0x1E98000</physicalOffset>
+        <physicalOffset>0x1EA2000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/45)
<!-- Reviewable:end -->
