### PR TITLE
update_image: -xz_compression is a boolean, so don't require an argument

### DIFF
--- a/update_image.pl
+++ b/update_image.pl
@@ -18,7 +18,7 @@ my $occ_binary_filename = "";
 my $capp_binary_filename = "";
 my $openpower_version_filename = "";
 my $payload = "";
-my $xz_compression = "false";
+my $xz_compression = 0;
 
 while (@ARGV > 0){
     $_ = $ARGV[0];
@@ -81,8 +81,7 @@ while (@ARGV > 0){
         shift;
     }
     elsif (/^-xz_compression/i){
-        $xz_compression = $ARGV[1] or die "Bad command line arg given: expecting xz compression flag.\n";
-        shift;
+        $xz_compression = 1;
     }
     else {
         print "Unrecognized command line arg: $_ \n";
@@ -93,7 +92,7 @@ while (@ARGV > 0){
 }
 
 # Compress the skiboot lid image with lzma
-if (($payload ne "") and ($xz_compression ne "false"))
+if (($payload ne "") and ($xz_compression))
 {
     run_command("xz -fk --check=crc32 $payload");
 }


### PR DESCRIPTION
Rather than using -xz_compression true/false, just use the presence of
the argument to signify xz_compression.

Also, store it as a boolean-readable value, rather than arbitrary
strings.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/49)
<!-- Reviewable:end -->
