### PR TITLE
Add WOFDATA to pnor layout

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -131,6 +131,9 @@ $build_pnor_command .= " --binFile_CAPP $scratch_dir/cappucode.bin.ecc";
 $build_pnor_command .= " --binFile_SECBOOT $scratch_dir/secboot.bin.ecc";
 $build_pnor_command .= " --binFile_VERSION $openpower_version_filename";
 $build_pnor_command .= " --binFile_IMA_CATALOG $scratch_dir/ima_catalog.bin.ecc";
+if ($release eq "p9"){
+    $build_pnor_command .= " --binFile_WOFDATA $scratch_dir/wofdata.bin.ecc";
+}
 if ($release eq "p8"){
     $build_pnor_command .= " --binFile_SBEC $scratch_dir/$sbec_binary_filename";
     $build_pnor_command .= " --binFile_WINK $scratch_dir/$wink_binary_filename";

--- a/p9Layouts/defaultPnorLayout_128.xml
+++ b/p9Layouts/defaultPnorLayout_128.xml
@@ -288,4 +288,14 @@ Layout Description
         <physicalRegionSize>0x20000</physicalRegionSize>
         <side>A</side>
     </section>
+    <section>
+        <description>VFRT data for WOF (3MB)</description>
+        <!-- We need 266KB per module sort, going to support
+             10 sorts by default, plus ECC  -->
+        <eyeCatch>WOFDATA</eyeCatch>
+        <physicalOffset>0x27C4000</physicalOffset>
+        <physicalRegionSize>0x300000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
+    </section>
 </pnor>

--- a/p9Layouts/defaultPnorLayout_32.xml
+++ b/p9Layouts/defaultPnorLayout_32.xml
@@ -288,4 +288,14 @@ Layout Description
         <physicalRegionSize>0x20000</physicalRegionSize>
         <side>A</side>
     </section>
+    <section>
+        <description>VFRT data for WOF (3MB)</description>
+        <!-- We need 266KB per module sort, going to support
+             10 sorts by default, plus ECC  -->
+        <eyeCatch>WOFDATA</eyeCatch>
+        <physicalOffset>0x27C4000</physicalOffset>
+        <physicalRegionSize>0x300000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
+    </section>
 </pnor>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -287,5 +287,15 @@ Layout Description
         <physicalOffset>0x2830000</physicalOffset>
         <physicalRegionSize>0x20000</physicalRegionSize>
         <side>A</side>
+    </section> 
+    <section>
+        <description>VFRT data for WOF (3MB)</description>
+        <!-- We need 266KB per module sort, going to support
+             10 sorts by default, plus ECC  -->
+        <eyeCatch>WOFDATA</eyeCatch>
+        <physicalOffset>0x2850000</physicalOffset>
+        <physicalRegionSize>0x300000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
     </section>
 </pnor>

--- a/update_image.pl
+++ b/update_image.pl
@@ -234,6 +234,13 @@ else
 
 run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/ima_catalog.bin.ecc --p8");
 
+#Create blank binary file for WOF/VFRT (WOFDATA) Partition  (for now)
+if ($release eq "p9") {
+    run_command("dd if=/dev/zero bs=2730K count=1 | tr \"\\000\" \"\\377\" >    $scratch_dir/hostboot.temp.bin");
+    run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/wofdata.bin.ecc --p8");
+}
+
+
 #END MAIN
 #-------------------------------------------------------------------------
 


### PR DESCRIPTION
Add the WOFDATA partition to the P9 PNOR layout xml files in
preparation to have code consume it.
Note - just filling partition with blank data for now, real data
will eventually come from system repos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/58)
<!-- Reviewable:end -->
