### PR TITLE
Adding WOFDATA support for the actual image

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -19,6 +19,7 @@ my $sbe_binary_filename = "";
 my $wink_binary_filename = "";
 my $occ_binary_filename = "";
 my $openpower_version_filename = "";
+my $wofdata_binary_filename = "";
 
 while (@ARGV > 0){
     $_ = $ARGV[0];
@@ -89,6 +90,10 @@ while (@ARGV > 0){
         $openpower_version_filename = $ARGV[1] or die "Bad command line arg given: expecting openpower version filename.\n";
         shift;
     }
+    elsif (/^-wofdata_binary_filename/i){
+        $wofdata_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a wofdata binary filename.\n";
+        shift;
+    }
     else {
         print "Unrecognized command line arg: $_ \n";
         print "To view all the options and help text run \'$program_name -h\' \n";
@@ -132,7 +137,7 @@ $build_pnor_command .= " --binFile_SECBOOT $scratch_dir/secboot.bin.ecc";
 $build_pnor_command .= " --binFile_VERSION $openpower_version_filename";
 $build_pnor_command .= " --binFile_IMA_CATALOG $scratch_dir/ima_catalog.bin.ecc";
 if ($release eq "p9"){
-    $build_pnor_command .= " --binFile_WOFDATA $scratch_dir/wofdata.bin.ecc";
+    $build_pnor_command .= " --binFile_WOFDATA $wofdata_binary_filename.ecc" if -e $wofdata_binary_filename.".ecc";
 }
 if ($release eq "p8"){
     $build_pnor_command .= " --binFile_SBEC $scratch_dir/$sbec_binary_filename";

--- a/update_image.pl
+++ b/update_image.pl
@@ -22,6 +22,7 @@ my $ima_catalog_binary_filename = "";
 my $openpower_version_filename = "";
 my $payload = "";
 my $xz_compression = 0;
+my $wof_binary_filename = "";
 
 while (@ARGV > 0){
     $_ = $ARGV[0];
@@ -97,6 +98,11 @@ while (@ARGV > 0){
     }
     elsif (/^-xz_compression/i){
         $xz_compression = 1;
+    }
+    elsif (/^-wof_binary_filename/i){
+        #This filename is necessary if the file exists, but if it's not given, we add a blank partition
+        $wof_binary_filename = $ARGV[1];
+        shift;
     }
     else {
         print "Unrecognized command line arg: $_ \n";
@@ -264,8 +270,15 @@ else
 
 run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/ima_catalog.bin.ecc --p8");
 
-#Create blank binary file for WOF/VFRT (WOFDATA) Partition  (for now)
-if ($release eq "p9") {
+#Encode ECC into WOF/VFRT (WOFDATA) Partition
+if ($release eq "p9" && -e $wof_binary_filename) {
+    run_command("dd if=$wof_binary_filename > $scratch_dir/hostboot.temp.bin");
+    run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/wofdata.bin.ecc");
+}
+#Print error and blank binary if wof file does not exist
+elsif ($release eq "p9")
+{
+    print "ERROR: WOFDATA partition is not found, including blank binary instead\n";
     run_command("dd if=/dev/zero bs=2730K count=1 | tr \"\\000\" \"\\377\" >    $scratch_dir/hostboot.temp.bin");
     run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/wofdata.bin.ecc --p8");
 }


### PR DESCRIPTION
This commit adds in the support to encode the wofdata image into the pnor image.  The actual image will be created in the op-build makefiles once the csv input file is finalized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/62)
<!-- Reviewable:end -->
