### PR TITLE
Add a semi persistent PNOR section for HB reconfig loops

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -136,6 +136,7 @@ $build_pnor_command .= " --binFile_CAPP $scratch_dir/cappucode.bin.ecc";
 $build_pnor_command .= " --binFile_SECBOOT $scratch_dir/secboot.bin.ecc";
 $build_pnor_command .= " --binFile_VERSION $openpower_version_filename";
 $build_pnor_command .= " --binFile_IMA_CATALOG $scratch_dir/ima_catalog.bin.ecc";
+
 if ($release eq "p9"){
     $build_pnor_command .= " --binFile_WOFDATA $wofdata_binary_filename" if -e $wofdata_binary_filename;
 }
@@ -146,6 +147,7 @@ if ($release eq "p8"){
     $build_pnor_command .= " --binFile_HCODE $scratch_dir/$wink_binary_filename";
     $build_pnor_command .= " --binFile_HBBL $scratch_dir/hbbl.bin.ecc";
     $build_pnor_command .= " --binFile_RINGOVD $scratch_dir/ringOvd.bin";
+    $build_pnor_command .= " --binFile_HB_VOLATILE $scratch_dir/guard.bin.ecc";
 }
 $build_pnor_command .= " --fpartCmd \"fpart\"";
 $build_pnor_command .= " --fcpCmd \"fcp\"";

--- a/p9Layouts/defaultPnorLayout_128.xml
+++ b/p9Layouts/defaultPnorLayout_128.xml
@@ -298,4 +298,13 @@ Layout Description
         <side>A</side>
         <ecc/>
     </section>
+    <section>
+        <description>Hostboot deconfig area (64KB)</description>
+        <eyeCatch>HB_VOLATILE</eyeCatch>
+        <physicalOffset>0x2AC4000</physicalOffset>
+        <physicalRegionSize>0x5000</physicalRegionSize>
+        <side>A</side>
+        <reprovision/>
+        <ecc/>
+    </section>
 </pnor>

--- a/p9Layouts/defaultPnorLayout_32.xml
+++ b/p9Layouts/defaultPnorLayout_32.xml
@@ -298,4 +298,12 @@ Layout Description
         <side>A</side>
         <ecc/>
     </section>
+    <section>
+        <description>Hostboot deconfig area (64KB)</description>
+        <eyeCatch>HB_VOLATILE</eyeCatch>
+        <physicalOffset>0x2AC4000</physicalOffset>
+        <physicalRegionSize>0x5000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
+    </section>
 </pnor>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -298,4 +298,12 @@ Layout Description
         <side>A</side>
         <ecc/>
     </section>
+    <section>
+        <description>Hostboot deconfig area (64KB)</description>
+        <eyeCatch>HB_VOLATILE</eyeCatch>
+        <physicalOffset>0x2B50000</physicalOffset>
+        <physicalRegionSize>0x5000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
+    </section>
 </pnor>


### PR DESCRIPTION
  - Hostboot needs a PNOR partition to store semi
    non-volatile data between reconfig reboots
  - BMC will clear on any true power down or BMC reboot,
    which leaves data intact on HB directed reboots

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pnor/64)
<!-- Reviewable:end -->
