### PR TITLE
Added back ATTR_PERM partition processing for P8 platforms

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -154,6 +154,7 @@ if ($release eq "p9"){
 if ($release eq "p8"){
     $build_pnor_command .= " --binFile_SBEC $scratch_dir/$sbec_binary_filename";
     $build_pnor_command .= " --binFile_WINK $scratch_dir/$wink_binary_filename";
+    $build_pnor_command .= " --binFile_ATTR_PERM $scratch_dir/attr_perm.bin.ecc";
 } else {
     $build_pnor_command .= " --binFile_SBKT $scratch_dir/SBKT.bin";
     $build_pnor_command .= " --binFile_HCODE $scratch_dir/$wink_binary_filename";

--- a/update_image.pl
+++ b/update_image.pl
@@ -272,6 +272,11 @@ sub processConvergedSections {
     $sections{SECBOOT}{out}     = "$scratch_dir/secboot.bin.ecc";
     $sections{RINGOVD}{out}     = "$scratch_dir/ringOvd.bin";
 
+    if($release eq "p8")
+    {
+        $sections{ATTR_PERM}{out}   = "$scratch_dir/attr_perm.bin.ecc";
+    }
+
     if(-e $wof_binary_filename)
     {
         $sections{WOFDATA}{in} = "$wof_binary_filename";
@@ -488,6 +493,13 @@ else
     # Create blank binary file for ATTR_TMP partition
     run_command("dd if=/dev/zero bs=28K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
     run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/attr_tmp.bin.ecc --p8");
+    
+    # Create blank binary file for ATTR_PERM partition
+    if($release eq "p8")
+    {
+        run_command("dd if=/dev/zero bs=28K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
+        run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/attr_perm.bin.ecc --p8");
+    }
 
     # Create blank binary file for FIRDATA partition
     run_command("dd if=/dev/zero bs=8K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");


### PR DESCRIPTION
    Removal of ATTR_PERM partition to enable HDAT parition
created IPL break for P8 platforms, since P8 still has the
ATTR_PERM partition in P8 pnor layout. Hence added it
back for P8 platforms.