### PR TITLE
Enable ATTR_PERM section in pnor for all CEC levels

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -140,6 +140,7 @@ $build_pnor_command .= " --binFile_DJVPD $scratch_dir/djvpd_fill.bin.ecc";
 $build_pnor_command .= " --binFile_CVPD $scratch_dir/cvpd.bin.ecc";
 $build_pnor_command .= " --binFile_ATTR_TMP $scratch_dir/attr_tmp.bin.ecc";
 $build_pnor_command .= " --binFile_OCC $occ_binary_filename.ecc";
+$build_pnor_command .= " --binFile_ATTR_PERM $scratch_dir/attr_perm.bin.ecc";
 $build_pnor_command .= " --binFile_FIRDATA $scratch_dir/firdata.bin.ecc";
 $build_pnor_command .= " --binFile_CAPP $scratch_dir/cappucode.bin.ecc";
 $build_pnor_command .= " --binFile_SECBOOT $scratch_dir/secboot.bin.ecc";
@@ -154,7 +155,6 @@ if ($release eq "p9"){
 if ($release eq "p8"){
     $build_pnor_command .= " --binFile_SBEC $scratch_dir/$sbec_binary_filename";
     $build_pnor_command .= " --binFile_WINK $scratch_dir/$wink_binary_filename";
-    $build_pnor_command .= " --binFile_ATTR_PERM $scratch_dir/attr_perm.bin.ecc";
 } else {
     $build_pnor_command .= " --binFile_SBKT $scratch_dir/SBKT.bin";
     $build_pnor_command .= " --binFile_HCODE $scratch_dir/$wink_binary_filename";

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -282,11 +282,6 @@ Layout Description
         <side>A</side>
         <reprovision/>
     </section>
-<!-- Commenting this temporarily as a workaround for accomadating 
-     new partition. Due to incorrect Toc size assumption, currently
-     we are unable to create more than 31 partitions. Until the 
-     proper fix comes in, commenting this out based on internal 
-     discussion.
     <section>
         <description>Permanent Attribute Override (32K)</description>
         <eyeCatch>ATTR_PERM</eyeCatch>
@@ -297,7 +292,6 @@ Layout Description
         <reprovision/>
         <clearOnEccErr/>
     </section>
--->
     <section>
         <description>PNOR Version (4K)</description>
         <eyeCatch>VERSION</eyeCatch>

--- a/update_image.pl
+++ b/update_image.pl
@@ -268,14 +268,10 @@ sub processConvergedSections {
     $sections{MVPD}{out}        = "$scratch_dir/mvpd_fill.bin.ecc";
     $sections{DJVPD}{out}       = "$scratch_dir/djvpd_fill.bin.ecc";
     $sections{ATTR_TMP}{out}    = "$scratch_dir/attr_tmp.bin.ecc";
+    $sections{ATTR_PERM}{out}   = "$scratch_dir/attr_perm.bin.ecc";
     $sections{FIRDATA}{out}     = "$scratch_dir/firdata.bin.ecc";
     $sections{SECBOOT}{out}     = "$scratch_dir/secboot.bin.ecc";
     $sections{RINGOVD}{out}     = "$scratch_dir/ringOvd.bin";
-
-    if($release eq "p8")
-    {
-        $sections{ATTR_PERM}{out}   = "$scratch_dir/attr_perm.bin.ecc";
-    }
 
     if(-e $wof_binary_filename)
     {
@@ -495,11 +491,8 @@ else
     run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/attr_tmp.bin.ecc --p8");
     
     # Create blank binary file for ATTR_PERM partition
-    if($release eq "p8")
-    {
-        run_command("dd if=/dev/zero bs=28K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
-        run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/attr_perm.bin.ecc --p8");
-    }
+    run_command("dd if=/dev/zero bs=28K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
+    run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/attr_perm.bin.ecc --p8");
 
     # Create blank binary file for FIRDATA partition
     run_command("dd if=/dev/zero bs=8K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");


### PR DESCRIPTION
Previously we were only generating the ATTR_PERM section for P8
as we were hitting a size limitation for the table of contents of
PNOR. New code has been added to the ffs tool to allow larger table
of contents for PNOR so this is no longer an issue. This commit
simply tells the script to generate a ATTR_PERM section for P9 now
that this limitation no longer exists