### PR TITLE
p9Layouts: Sign VERSION partition

### DIFF
--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -299,14 +299,15 @@ Layout Description
         <description>PNOR Version (4K)</description>
         <eyeCatch>VERSION</eyeCatch>
         <physicalOffset>0x2C08000</physicalOffset>
-        <physicalRegionSize>0x1000</physicalRegionSize>
+        <physicalRegionSize>0x2000</physicalRegionSize>
         <side>A</side>
+        <sha512Version/>
         <readOnly/>
     </section>
     <section>
         <description>IMA Catalog (256K)</description>
         <eyeCatch>IMA_CATALOG</eyeCatch>
-        <physicalOffset>0x2C09000</physicalOffset>
+        <physicalOffset>0x2C0A000</physicalOffset>
         <physicalRegionSize>0x40000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -316,7 +317,7 @@ Layout Description
     <section>
         <description>Ref Image Ring Overrides (128K)</description>
         <eyeCatch>RINGOVD</eyeCatch>
-        <physicalOffset>0x2C49000</physicalOffset>
+        <physicalOffset>0x2C4A000</physicalOffset>
         <physicalRegionSize>0x20000</physicalRegionSize>
         <side>A</side>
     </section>
@@ -325,7 +326,7 @@ Layout Description
         <!-- We need 266KB per module sort, going to support
              10 sorts by default, plus ECC  -->
         <eyeCatch>WOFDATA</eyeCatch>
-        <physicalOffset>0x2C69000</physicalOffset>
+        <physicalOffset>0x2C6A000</physicalOffset>
         <physicalRegionSize>0x300000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -335,7 +336,7 @@ Layout Description
     <section>
         <description>Hostboot deconfig area (64KB)</description>
         <eyeCatch>HB_VOLATILE</eyeCatch>
-        <physicalOffset>0x2F69000</physicalOffset>
+        <physicalOffset>0x2F6A000</physicalOffset>
         <physicalRegionSize>0x5000</physicalRegionSize>
         <side>A</side>
         <reprovision/>
@@ -346,7 +347,7 @@ Layout Description
     <section>
         <description>Memory config data (28K)</description>
         <eyeCatch>MEMD</eyeCatch>
-        <physicalOffset>0x2F6E000</physicalOffset>
+        <physicalOffset>0x2F6F000</physicalOffset>
         <physicalRegionSize>0xE000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -356,7 +357,7 @@ Layout Description
     <section>
         <description>SecureBoot Key Transition Partition (16K)</description>
         <eyeCatch>SBKT</eyeCatch>
-        <physicalOffset>0x2F82000</physicalOffset>
+        <physicalOffset>0x2F7D000</physicalOffset>
         <physicalRegionSize>0x4000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -366,7 +367,7 @@ Layout Description
     <section>
         <description>HDAT binary data (16KB)</description>
         <eyeCatch>HDAT</eyeCatch>
-        <physicalOffset>0x2F86000</physicalOffset>
+        <physicalOffset>0x2F81000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>


### PR DESCRIPTION
And update the partition offsets to match since the VERSION partition
needs an extra 4K to fit the signed header.

Partial fix for https://github.com/open-power/op-build/issues/1849

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>