### PR TITLE
Support Optional Attribute/Targeting Read-Write PNOR Partition

### DIFF
--- a/p8Layouts/defaultPnorLayoutSingleSide.xml
+++ b/p8Layouts/defaultPnorLayoutSingleSide.xml
@@ -109,10 +109,19 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Hostboot Data (0.375M)</description>
+        <description>Hostboot Data (320K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x6D0000</physicalOffset>
-        <physicalRegionSize>0x60000</physicalRegionSize>
+        <physicalRegionSize>0x50000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
+        <readOnly/>
+    </section>
+    <section>
+        <description>Hostboot Data : Read-Write (64K)</description>
+        <eyeCatch>HBD_RW</eyeCatch>
+        <physicalOffset>0x720000</physicalOffset>
+        <physicalRegionSize>0x10000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>

--- a/p8Layouts/defaultPnorLayoutWithGoldenSide.xml
+++ b/p8Layouts/defaultPnorLayoutWithGoldenSide.xml
@@ -97,10 +97,19 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Hostboot Data (.375M)</description>
+        <description>Hostboot Data (320K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x31000</physicalOffset>
-        <physicalRegionSize>0x60000</physicalRegionSize>
+        <physicalRegionSize>0x50000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
+        <readOnly/>
+    </section>
+    <section>
+        <description>Hostboot Data : Read-Write (64K)</description>
+        <eyeCatch>HBD_RW</eyeCatch>
+        <physicalOffset>0x81000</physicalOffset>
+        <physicalRegionSize>0x10000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>
@@ -312,10 +321,19 @@ Layout Description
     </section>
     <!-- Golden Side (Side B) -->
     <section>
-        <description>Hostboot Data (0.375M)</description>
+        <description>Hostboot Data (320K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x2008000</physicalOffset>
-        <physicalRegionSize>0x60000</physicalRegionSize>
+        <physicalRegionSize>0x50000</physicalRegionSize>
+        <side>B</side>
+        <readOnly/>
+        <ecc/>
+    </section>
+    <section>
+        <description>Hostboot Data : Read-Write (64K)</description>
+        <eyeCatch>HBD_RW</eyeCatch>
+        <physicalOffset>0x2058000</physicalOffset>
+        <physicalRegionSize>0x10000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
         <ecc/>

--- a/p8Layouts/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/p8Layouts/defaultPnorLayoutWithoutGoldenSide.xml
@@ -96,10 +96,19 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Hostboot Data (.375M)</description>
+        <description>Hostboot Data (320K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x31000</physicalOffset>
-        <physicalRegionSize>0x60000</physicalRegionSize>
+        <physicalRegionSize>0x50000</physicalRegionSize>
+        <side>A</side>
+        <ecc/>
+        <readOnly/>
+    </section>
+    <section>
+        <description>Hostboot Data : Read-Write (64K)</description>
+        <eyeCatch>HBD_RW</eyeCatch>
+        <physicalOffset>0x81000</physicalOffset>
+        <physicalRegionSize>0x10000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>
@@ -311,10 +320,19 @@ Layout Description
     </section>
     <!-- Golden Side (Side B) -->
     <section>
-        <description>Hostboot Data (0.375M)</description>
+        <description>Hostboot Data (320K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x2008000</physicalOffset>
-        <physicalRegionSize>0x60000</physicalRegionSize>
+        <physicalRegionSize>0x50000</physicalRegionSize>
+        <side>B</side>
+        <ecc/>
+        <readOnly>
+    </section>
+    <section>
+        <description>Hostboot Data : Read-Write (64K)</description>
+        <eyeCatch>HBD_RW</eyeCatch>
+        <physicalOffset>0x2058000</physicalOffset>
+        <physicalRegionSize>0x10000</physicalRegionSize>
         <side>B</side>
         <ecc/>
     </section>

--- a/update_image.pl
+++ b/update_image.pl
@@ -14,6 +14,10 @@ my $hcode_dir = "";
 my $sbe_binary_dir = "";
 my $targeting_binary_filename = "";
 my $targeting_binary_source = "";
+my $targeting_RO_binary_filename = "";
+my $targeting_RO_binary_source = "";
+my $targeting_RW_binary_filename = "";
+my $targeting_RW_binary_source = "";
 my $sbe_binary_filename = "";
 my $sbec_binary_filename = "";
 my $wink_binary_filename = "";
@@ -77,6 +81,22 @@ while (@ARGV > 0){
     }
     elsif (/^-targeting_binary_source/i){
         $targeting_binary_source = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
+        shift;
+    }
+    elsif (/^-targeting_RO_binary_filename/i){
+        $targeting_RO_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
+        shift;
+    }
+    elsif (/^-targeting_RO_binary_source/i){
+        $targeting_RO_binary_source = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
+        shift;
+    }
+    elsif (/^-targeting_RW_binary_filename/i){
+        $targeting_RW_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
+        shift;
+    }
+    elsif (/^-targeting_RW_binary_source/i){
+        $targeting_RW_binary_source = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
         shift;
     }
     elsif (/^-sbe_binary_filename/i){
@@ -414,9 +434,28 @@ if ($release ne "p8") {
 }
 else
 {
-    # Inject ECC into HBD (hostboot targeting) output binary
-    run_command("dd if=$op_target_dir/$targeting_binary_source of=$scratch_dir/$targeting_binary_source ibs=4k conv=sync");
-    run_command("ecc --inject $scratch_dir/$targeting_binary_source --output $scratch_dir/$targeting_binary_filename --p8");
+    # Inject ECC into any of the HBD (hostboot targeting) output binaries
+    if (-e "$op_target_dir/$targeting_binary_source")
+    {
+        print "Processing targeting_binary_source: $op_target_dir/$targeting_binary_source\n";
+        run_command("dd if=$op_target_dir/$targeting_binary_source of=$scratch_dir/$targeting_binary_source ibs=4k conv=sync");
+        run_command("ecc --inject $scratch_dir/$targeting_binary_source --output $scratch_dir/$targeting_binary_filename --p8");
+    }
+
+    if(-e "$op_target_dir/$targeting_RO_binary_source")
+    {
+        print "Processing targeting_RO_binary_source: $op_target_dir/$targeting_RO_binary_source\n";
+        run_command("dd if=$op_target_dir/$targeting_RO_binary_source of=$scratch_dir/$targeting_RO_binary_source ibs=4k conv=sync");
+        run_command("ecc --inject $scratch_dir/$targeting_RO_binary_source --output $scratch_dir/$targeting_RO_binary_filename --p8");
+
+    }
+
+    if(-e "$op_target_dir/$targeting_RW_binary_source")
+    {
+        print "Processing targeting_RW_binary_source: $op_target_dir/$targeting_RW_binary_source\n";
+        run_command("dd if=$op_target_dir/$targeting_RW_binary_source of=$scratch_dir/$targeting_RW_binary_source ibs=4k conv=sync");
+        run_command("ecc --inject $scratch_dir/$targeting_RW_binary_source --output $scratch_dir/$targeting_RW_binary_filename --p8");
+    }
 
     # Add SBE/normal headers and inject ECC into HBB (hostboot base) partition binary
     run_command("echo \"00000000001800000000000008000000000000000007EF80\" | xxd -r -ps - $scratch_dir/sbe.header");


### PR DESCRIPTION
This commit addes support for an optional Attribute/Targeting
Read-Write PNOR Partition (HBD_RW).  If it exists then original
Attribute/Targeting PNOR Partition (HBD) only contains the READ-ONLY
data.  If HBD_RW does not exist, then HBD contains both the READ-ONLY
and Read-Write sections as it has historically.