### PR TITLE
Update HBD/HBD_RW Partition Sizes to fix VESNIN Config Compile Issues

### DIFF
--- a/p8Layouts/defaultPnorLayoutSingleSide.xml
+++ b/p8Layouts/defaultPnorLayoutSingleSide.xml
@@ -109,19 +109,19 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Hostboot Data (320K)</description>
+        <description>Hostboot Data (360K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x6D0000</physicalOffset>
-        <physicalRegionSize>0x50000</physicalRegionSize>
+        <physicalRegionSize>0x5A000</physicalRegionSize>
         <side>A</side>
         <ecc/>
         <readOnly/>
     </section>
     <section>
-        <description>Hostboot Data : Read-Write (64K)</description>
+        <description>Hostboot Data : Read-Write (24K)</description>
         <eyeCatch>HBD_RW</eyeCatch>
-        <physicalOffset>0x720000</physicalOffset>
-        <physicalRegionSize>0x10000</physicalRegionSize>
+        <physicalOffset>0x72A000</physicalOffset>
+        <physicalRegionSize>0x6000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>

--- a/p8Layouts/defaultPnorLayoutWithGoldenSide.xml
+++ b/p8Layouts/defaultPnorLayoutWithGoldenSide.xml
@@ -97,19 +97,19 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Hostboot Data (320K)</description>
+        <description>Hostboot Data (360K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x31000</physicalOffset>
-        <physicalRegionSize>0x50000</physicalRegionSize>
+        <physicalRegionSize>0x5A000</physicalRegionSize>
         <side>A</side>
         <ecc/>
         <readOnly/>
     </section>
     <section>
-        <description>Hostboot Data : Read-Write (64K)</description>
+        <description>Hostboot Data : Read-Write (24K)</description>
         <eyeCatch>HBD_RW</eyeCatch>
-        <physicalOffset>0x81000</physicalOffset>
-        <physicalRegionSize>0x10000</physicalRegionSize>
+        <physicalOffset>0x8B000</physicalOffset>
+        <physicalRegionSize>0x6000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>
@@ -321,19 +321,19 @@ Layout Description
     </section>
     <!-- Golden Side (Side B) -->
     <section>
-        <description>Hostboot Data (320K)</description>
+        <description>Hostboot Data (360K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x2008000</physicalOffset>
-        <physicalRegionSize>0x50000</physicalRegionSize>
+        <physicalRegionSize>0x5A000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Data : Read-Write (64K)</description>
+        <description>Hostboot Data : Read-Write (24K)</description>
         <eyeCatch>HBD_RW</eyeCatch>
-        <physicalOffset>0x2058000</physicalOffset>
-        <physicalRegionSize>0x10000</physicalRegionSize>
+        <physicalOffset>0x2062000</physicalOffset>
+        <physicalRegionSize>0x6000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
         <ecc/>

--- a/p8Layouts/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/p8Layouts/defaultPnorLayoutWithoutGoldenSide.xml
@@ -96,19 +96,19 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Hostboot Data (320K)</description>
+        <description>Hostboot Data (360K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x31000</physicalOffset>
-        <physicalRegionSize>0x50000</physicalRegionSize>
+        <physicalRegionSize>0x5A000</physicalRegionSize>
         <side>A</side>
         <ecc/>
         <readOnly/>
     </section>
     <section>
-        <description>Hostboot Data : Read-Write (64K)</description>
+        <description>Hostboot Data : Read-Write (24K)</description>
         <eyeCatch>HBD_RW</eyeCatch>
-        <physicalOffset>0x81000</physicalOffset>
-        <physicalRegionSize>0x10000</physicalRegionSize>
+        <physicalOffset>0x8B000</physicalOffset>
+        <physicalRegionSize>0x6000</physicalRegionSize>
         <side>A</side>
         <ecc/>
     </section>
@@ -320,19 +320,19 @@ Layout Description
     </section>
     <!-- Golden Side (Side B) -->
     <section>
-        <description>Hostboot Data (320K)</description>
+        <description>Hostboot Data (360K)</description>
         <eyeCatch>HBD</eyeCatch>
         <physicalOffset>0x2008000</physicalOffset>
-        <physicalRegionSize>0x50000</physicalRegionSize>
+        <physicalRegionSize>0x5A000</physicalRegionSize>
         <side>B</side>
         <ecc/>
         <readOnly>
     </section>
     <section>
-        <description>Hostboot Data : Read-Write (64K)</description>
+        <description>Hostboot Data : Read-Write (24K)</description>
         <eyeCatch>HBD_RW</eyeCatch>
-        <physicalOffset>0x2058000</physicalOffset>
-        <physicalRegionSize>0x10000</physicalRegionSize>
+        <physicalOffset>0x2062000</physicalOffset>
+        <physicalRegionSize>0x6000</physicalRegionSize>
         <side>B</side>
         <ecc/>
     </section>


### PR DESCRIPTION
This commit rebalances the allocated size of 0x60000 for the P8
HBD/HBD_RW partitions to more properly reflect that for P8 systems
there is much more read-only attribute data (which goes into HBD)
then there is read-write data (which goes into HBD_RW).