### PR TITLE
Revert "Add UVBWLIST Partition"

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -174,7 +174,6 @@ if ($release eq "p9"){
     $build_pnor_command .= " --binFile_WOFDATA $wofdata_binary_filename" if -e $wofdata_binary_filename;
     $build_pnor_command .= " --binFile_MEMD $memddata_binary_filename" if -e $memddata_binary_filename;
     $build_pnor_command .= " --binFile_HDAT $hdat_binary_filename" if -e $hdat_binary_filename;
-    $build_pnor_command .= " --binFile_UVBWLIST $scratch_dir/uvbwlist.bin";
 }
 if ($release eq "p8"){
     $build_pnor_command .= " --binFile_SBEC $scratch_dir/$sbec_binary_filename";

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -396,13 +396,4 @@ Layout Description
         <readOnly/>
         <ecc/>
     </section>
-    <section>
-        <description>Ultravisor XSCOM White/Blacklist (64K)</description>
-        <eyeCatch>UVBWLIST</eyeCatch>
-        <physicalOffset>0x34F4000</physicalOffset>
-        <physicalRegionSize>0x10000</physicalRegionSize>
-        <side>sideless</side>
-        <sha512Version/>
-        <readOnly/>
-    </section>
 </pnor>

--- a/update_image.pl
+++ b/update_image.pl
@@ -305,7 +305,6 @@ sub processConvergedSections {
     $sections{FIRDATA}{out}     = "$scratch_dir/firdata.bin.ecc";
     $sections{SECBOOT}{out}     = "$scratch_dir/secboot.bin.ecc";
     $sections{RINGOVD}{out}     = "$scratch_dir/ringOvd.bin";
-    $sections{UVBWLIST}{out}    = "$scratch_dir/uvbwlist.bin";
 
     if(-e $wof_binary_filename)
     {


### PR DESCRIPTION
UVBWLIST is no longer needed as a PNOR partition. The passing
of Ultravisor white/blacklist will be done via an SBE chip op
instead.

This reverts commit d62c8ee5be943084263905e9a9c0a879368e84f1.