### PR TITLE
Edit of Layouts for GCC 8 Changes

### DIFF
--- a/p8Layouts/defaultPnorLayoutSingleSide.xml
+++ b/p8Layouts/defaultPnorLayoutSingleSide.xml
@@ -192,18 +192,18 @@ Layout Description
         <reprovision/>
     </section>
     <section>
-        <description>Payload (1MB)</description>
+        <description>Payload (0.5MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0x961000</physicalOffset>
-        <physicalRegionSize>0x100000</physicalRegionSize>
+        <physicalRegionSize>0x80000</physicalRegionSize>
         <side>A</side>
         <readOnly/>
     </section>
     <section>
-        <description>Bootloader Kernel (15MB)</description>
+        <description>Bootloader Kernel (15.5MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0xA61000</physicalOffset>
-        <physicalRegionSize>0xF00000</physicalRegionSize>
+        <physicalOffset>0x9E1000</physicalOffset>
+        <physicalRegionSize>0xF80000</physicalRegionSize>
         <side>A</side>
         <readOnly/>
     </section>

--- a/p8Layouts/defaultPnorLayoutWithGoldenSide.xml
+++ b/p8Layouts/defaultPnorLayoutWithGoldenSide.xml
@@ -194,18 +194,18 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (1MB)</description>
+        <description>Payload (0.5MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0xCA9000</physicalOffset>
-        <physicalRegionSize>0x100000</physicalRegionSize>
+        <physicalRegionSize>0x80000</physicalRegionSize>
         <side>A</side>
         <readOnly/>
     </section>
     <section>
-        <description>Bootloader Kernel (15MB)</description>
+        <description>Bootloader Kernel (15.5MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0xDA9000</physicalOffset>
-        <physicalRegionSize>0xF00000</physicalRegionSize>
+        <physicalOffset>0xD29000</physicalOffset>
+        <physicalRegionSize>0xF80000</physicalRegionSize>
         <side>A</side>
         <readOnly/>
     </section>
@@ -389,22 +389,22 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (1MB)</description>
+        <description>Payload (0.5MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0x2C80000</physicalOffset>
-        <physicalRegionSize>0x100000</physicalRegionSize>
+        <physicalRegionSize>0x80000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
         <compressed>
             <algorithm>xz</algorithm>
-            <uncompressedSize>0x100000</uncompressedSize>
+            <uncompressedSize>0x80000</uncompressedSize>
         </compressed>
     </section>
     <section>
-        <description>Bootloader Kernel (15MB)</description>
+        <description>Bootloader Kernel (15.5MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0x2D80000</physicalOffset>
-        <physicalRegionSize>0xF00000</physicalRegionSize>
+        <physicalOffset>0x2D00000</physicalOffset>
+        <physicalRegionSize>0xF80000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
     </section>

--- a/p8Layouts/defaultPnorLayoutWithoutGoldenSide.xml
+++ b/p8Layouts/defaultPnorLayoutWithoutGoldenSide.xml
@@ -193,18 +193,18 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (1MB)</description>
+        <description>Payload (0.5MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0xCA9000</physicalOffset>
-        <physicalRegionSize>0x100000</physicalRegionSize>
+        <physicalRegionSize>0x80000</physicalRegionSize>
         <side>A</side>
         <readOnly/>
     </section>
     <section>
-        <description>Bootloader Kernel (15MB)</description>
+        <description>Bootloader Kernel (15.5MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0xDA9000</physicalOffset>
-        <physicalRegionSize>0xF00000</physicalRegionSize>
+        <physicalOffset>0xD29000</physicalOffset>
+        <physicalRegionSize>0xF80000</physicalRegionSize>
         <side>A</side>
         <readOnly/>
     </section>
@@ -387,22 +387,22 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (1MB)</description>
+        <description>Payload (0.5MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0x2C80000</physicalOffset>
-        <physicalRegionSize>0x100000</physicalRegionSize>
+        <physicalRegionSize>0x80000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
         <compressed>
             <algorithm>xz</algorithm>
-            <uncompressedSize>0x100000</uncompressedSize>
+            <uncompressedSize>0x80000</uncompressedSize>
         </compressed>
     </section>
     <section>
-        <description>Bootloader Kernel (15MB)</description>
+        <description>Bootloader Kernel (15.5MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0x2D80000</physicalOffset>
-        <physicalRegionSize>0xF00000</physicalRegionSize>
+        <physicalOffset>0x2D00000</physicalOffset>
+        <physicalRegionSize>0xF80000</physicalRegionSize>
         <side>B</side>
         <readOnly/>
     </section>

--- a/p9Layouts/axonePnorLayout_64.xml
+++ b/p9Layouts/axonePnorLayout_64.xml
@@ -178,19 +178,19 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (1MB)</description>
+        <description>Payload (0.5MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0x2081000</physicalOffset>
-        <physicalRegionSize>0x100000</physicalRegionSize>
+        <physicalRegionSize>0x80000</physicalRegionSize>
         <sha512Version/>
         <side>sideless</side>
         <readOnly/>
     </section>
     <section>
-        <description>Bootloader Kernel (15MB)</description>
+        <description>Bootloader Kernel (15.5MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0x2181000</physicalOffset>
-        <physicalRegionSize>0xF00000</physicalRegionSize>
+        <physicalOffset>0x2101000</physicalOffset>
+        <physicalRegionSize>0xF80000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
         <readOnly/>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -213,19 +213,19 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (1MB)</description>
+        <description>Payload (0.5MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
         <physicalOffset>0x20C1000</physicalOffset>
-        <physicalRegionSize>0x100000</physicalRegionSize>
+        <physicalRegionSize>0x80000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
         <readOnly/>
     </section>
     <section>
-        <description>Bootloader Kernel (15MB)</description>
+        <description>Bootloader Kernel (15.5MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0x21C1000</physicalOffset>
-        <physicalRegionSize>0xF00000</physicalRegionSize>
+        <physicalOffset>0x2141000</physicalOffset>
+        <physicalRegionSize>0xF80000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
         <readOnly/>


### PR DESCRIPTION
While compiling with GCC 8, Bootloader Kernel size needed to be increase by 1 MB.