### PR TITLE
Update pnor generation scripts to fill in ECC for EECACHE section

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -198,6 +198,11 @@ if (checkForPnorPartition("MVPD", $parsed_pnor_layout))
     $build_pnor_command .= " --binFile_MVPD $scratch_dir/mvpd_fill.bin.ecc";
 }
 
+if (checkForPnorPartition("EECACHE", $parsed_pnor_layout))
+{
+    $build_pnor_command .= " --binFile_EECACHE $scratch_dir/eecache_fill.bin.ecc";
+}
+
 if (checkForPnorPartition("OCMBFW", $parsed_pnor_layout))
 {
     $build_pnor_command .= " --binFile_OCMBFW $ocmbfw_binary_filename";

--- a/update_image.pl
+++ b/update_image.pl
@@ -351,6 +351,11 @@ sub processConvergedSections {
         $sections{MVPD}{out}    = "$scratch_dir/mvpd_fill.bin.ecc";
     }
 
+    if (checkForPnorPartition("EECACHE", $parsed_pnor_layout))
+    {
+        $sections{EECACHE}{out}    = "$scratch_dir/eecache_fill.bin.ecc";
+    }
+
     if(-e $wof_binary_filename)
     {
         $sections{WOFDATA}{in} = "$wof_binary_filename";
@@ -601,6 +606,10 @@ else
 
     # Create blank binary file for NVRAM partition
     run_command("dd if=/dev/zero bs=512K count=1 of=$scratch_dir/nvram.bin");
+
+    # Create blank binary file for EECACHE partition
+    run_command("dd if=/dev/zero bs=512K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
+    run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/eecache_fill.bin.ecc --p8");
 
     # Create blank binary file for MVPD partition
     run_command("dd if=/dev/zero bs=512K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");


### PR DESCRIPTION
In Axone systems and onwards there is a new EEACHE section which
has been introduced. As this section is essentially replacement
of the CVPD/MVPD/DJVPD section it too needs to be initialized with
ECC.