### PR TITLE
Revert "Add OCMBFW Partition"

### DIFF
--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -386,14 +386,4 @@ Layout Description
         <sha512Version/>
         <readOnly/>
     </section>
-    <section>
-        <description>Open CAPI Memory Buffer (OCMB) Firmware (300K)</description>
-        <eyeCatch>OCMBFW</eyeCatch>
-        <physicalOffset>0x36A9000</physicalOffset>
-        <physicalRegionSize>0x4B000</physicalRegionSize>
-        <side>sideless</side>
-        <sha512Version/>
-        <readOnly/>
-        <ecc/>
-    </section>
 </pnor>


### PR DESCRIPTION
This reverts commit 122bebe03e545b0c3b3051171aca830276cdefbc. It
is no longer needed in the defaultPnorLayout file and now
is in the axonePnorLayout file.

Signed-off-by: Bill Hoffa <wghoffa@us.ibm.com>