### PR TITLE
Re-apply axone layout changes and make script changed needed

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -211,7 +211,10 @@ if (checkForPnorPartition("OCMBFW", $parsed_pnor_layout))
 # Add sections based on processor family type
 if ($release eq "p9"){
     $build_pnor_command .= " --binFile_WOFDATA $wofdata_binary_filename" if -e $wofdata_binary_filename;
-    $build_pnor_command .= " --binFile_MEMD $memddata_binary_filename" if -e $memddata_binary_filename;
+    if (checkForPnorPartition("MEMD", $parsed_pnor_layout))
+    {
+        $build_pnor_command .= " --binFile_MEMD $memddata_binary_filename" if -e $memddata_binary_filename;
+    }
     $build_pnor_command .= " --binFile_HDAT $hdat_binary_filename" if -e $hdat_binary_filename;
 }
 if ($release eq "p8"){

--- a/p9Layouts/axonePnorLayout_64.xml
+++ b/p9Layouts/axonePnorLayout_64.xml
@@ -118,9 +118,20 @@ Layout Description
         <preserved/>
     </section>
     <section>
+        <description>Eeprom Cache(512K)</description>
+        <eyeCatch>EECACHE</eyeCatch>
+        <physicalOffset>0xE5000</physicalOffset>
+        <physicalRegionSize>0x80000</physicalRegionSize>
+        <side>sideless</side>
+        <ecc/>
+        <preserved/>
+        <reprovision/>
+        <clearOnEccErr/>
+    </section>
+    <section>
         <description>Hostboot Base (1MB)</description>
         <eyeCatch>HBB</eyeCatch>
-        <physicalOffset>0xE5000</physicalOffset>
+        <physicalOffset>0x165000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -130,26 +141,16 @@ Layout Description
     <section>
         <description>Hostboot Data (2MB)</description>
         <eyeCatch>HBD</eyeCatch>
-        <physicalOffset>0x1E5000</physicalOffset>
+        <physicalOffset>0x265000</physicalOffset>
         <physicalRegionSize>0x200000</physicalRegionSize>
         <sha512Version/>
         <side>sideless</side>
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Extended image (16.67MB w/o ECC)</description>
-        <eyeCatch>HBI</eyeCatch>
-        <physicalOffset>0x3E5000</physicalOffset>
-        <physicalRegionSize>0x12C0000</physicalRegionSize>
-        <sha512Version/>
-        <side>sideless</side>
-        <readOnly/>
-        <ecc/>
-    </section>
-    <section>
         <description>SBE-IPL (Staging Area) (752K)</description>
         <eyeCatch>SBE</eyeCatch>
-        <physicalOffset>0x16A5000</physicalOffset>
+        <physicalOffset>0x465000</physicalOffset>
         <physicalRegionSize>0xBC000</physicalRegionSize>
         <sha512perEC/>
         <sha512Version/>
@@ -160,7 +161,7 @@ Layout Description
     <section>
         <description>HCODE Ref Image (1.125MB)</description>
         <eyeCatch>HCODE</eyeCatch>
-        <physicalOffset>0x1761000</physicalOffset>
+        <physicalOffset>0x521000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <sha512Version/>
         <side>sideless</side>
@@ -170,7 +171,7 @@ Layout Description
     <section>
         <description>Hostboot Runtime Services for Sapphire (8.0MB)</description>
         <eyeCatch>HBRT</eyeCatch>
-        <physicalOffset>0x1881000</physicalOffset>
+        <physicalOffset>0x641000</physicalOffset>
         <physicalRegionSize>0x800000</physicalRegionSize>
         <sha512Version/>
         <side>sideless</side>
@@ -180,7 +181,7 @@ Layout Description
     <section>
         <description>Payload (0.5MB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalOffset>0x2081000</physicalOffset>
+        <physicalOffset>0xE41000</physicalOffset>
         <physicalRegionSize>0x80000</physicalRegionSize>
         <sha512Version/>
         <side>sideless</side>
@@ -189,7 +190,7 @@ Layout Description
     <section>
         <description>Bootloader Kernel (15.5MB)</description>
         <eyeCatch>BOOTKERNEL</eyeCatch>
-        <physicalOffset>0x2101000</physicalOffset>
+        <physicalOffset>0xEC1000</physicalOffset>
         <physicalRegionSize>0xF80000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -198,7 +199,7 @@ Layout Description
     <section>
         <description>OCC Lid (1.125M)</description>
         <eyeCatch>OCC</eyeCatch>
-        <physicalOffset>0x3081000</physicalOffset>
+        <physicalOffset>0x1E41000</physicalOffset>
         <physicalRegionSize>0x120000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -208,7 +209,7 @@ Layout Description
     <section>
         <description>Checkstop FIR data (12K)</description>
         <eyeCatch>FIRDATA</eyeCatch>
-        <physicalOffset>0x31A1000</physicalOffset>
+        <physicalOffset>0x1F61000</physicalOffset>
         <physicalRegionSize>0x3000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -218,7 +219,7 @@ Layout Description
     <section>
         <description>CAPP Lid (144K)</description>
         <eyeCatch>CAPP</eyeCatch>
-        <physicalOffset>0x31A4000</physicalOffset>
+        <physicalOffset>0x1F64000</physicalOffset>
         <physicalRegionSize>0x24000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -228,7 +229,7 @@ Layout Description
     <section>
         <description>BMC Inventory (36K)</description>
         <eyeCatch>BMC_INV</eyeCatch>
-        <physicalOffset>0x31C8000</physicalOffset>
+        <physicalOffset>0x1F88000</physicalOffset>
         <physicalRegionSize>0x9000</physicalRegionSize>
         <side>sideless</side>
         <reprovision/>
@@ -236,7 +237,7 @@ Layout Description
     <section>
         <description>Hostboot Bootloader (28K)</description>
         <eyeCatch>HBBL</eyeCatch>
-        <physicalOffset>0x31D1000</physicalOffset>
+        <physicalOffset>0x1F91000</physicalOffset>
         <!-- Physical Size includes Header rounded to ECC valid size -->
         <!-- Max size of actual HBBL content is 20K and 22.5K with ECC -->
         <physicalRegionSize>0x7000</physicalRegionSize>
@@ -248,7 +249,7 @@ Layout Description
     <section>
         <description>Temporary Attribute Override (32K)</description>
         <eyeCatch>ATTR_TMP</eyeCatch>
-        <physicalOffset>0x31D8000</physicalOffset>
+        <physicalOffset>0x1F98000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <reprovision/>
@@ -256,7 +257,7 @@ Layout Description
     <section>
         <description>PNOR Version (4K)</description>
         <eyeCatch>VERSION</eyeCatch>
-        <physicalOffset>0x31E0000</physicalOffset>
+        <physicalOffset>0x1FA0000</physicalOffset>
         <physicalRegionSize>0x2000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -265,7 +266,7 @@ Layout Description
     <section>
         <description>Permanent Attribute Override (32K)</description>
         <eyeCatch>ATTR_PERM</eyeCatch>
-        <physicalOffset>0x31E2000</physicalOffset>
+        <physicalOffset>0x1FA2000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <ecc/>
@@ -275,7 +276,7 @@ Layout Description
     <section>
         <description>IMA Catalog (256K)</description>
         <eyeCatch>IMA_CATALOG</eyeCatch>
-        <physicalOffset>0x31EA000</physicalOffset>
+        <physicalOffset>0x1FAA000</physicalOffset>
         <physicalRegionSize>0x40000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -285,7 +286,7 @@ Layout Description
     <section>
         <description>Ref Image Ring Overrides (128K)</description>
         <eyeCatch>RINGOVD</eyeCatch>
-        <physicalOffset>0x322A000</physicalOffset>
+        <physicalOffset>0x1FEA000</physicalOffset>
         <physicalRegionSize>0x20000</physicalRegionSize>
         <side>sideless</side>
     </section>
@@ -294,7 +295,7 @@ Layout Description
         <!-- We need 266KB per module sort, going to support
                           10 tables by default, plus ECC  -->
         <eyeCatch>WOFDATA</eyeCatch>
-        <physicalOffset>0x324A000</physicalOffset>
+        <physicalOffset>0x200A000</physicalOffset>
         <physicalRegionSize>0x300000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -304,7 +305,7 @@ Layout Description
     <section>
         <description>Hostboot deconfig area (20KB)</description>
         <eyeCatch>HB_VOLATILE</eyeCatch>
-        <physicalOffset>0x354A000</physicalOffset>
+        <physicalOffset>0x230A000</physicalOffset>
         <physicalRegionSize>0x5000</physicalRegionSize>
         <side>sideless</side>
         <reprovision/>
@@ -313,19 +314,9 @@ Layout Description
         <clearOnEccErr/>
     </section>
     <section>
-        <description>Memory Data (56K)</description>
-        <eyeCatch>MEMD</eyeCatch>
-        <physicalOffset>0x354F000</physicalOffset>
-        <physicalRegionSize>0xE000</physicalRegionSize>
-        <side>sideless</side>
-        <sha512Version/>
-        <readOnly/>
-        <ecc/>
-    </section>
-    <section>
         <description>SecureBoot Key Transition Partition (16K)</description>
         <eyeCatch>SBKT</eyeCatch>
-        <physicalOffset>0x355D000</physicalOffset>
+        <physicalOffset>0x230F000</physicalOffset>
         <physicalRegionSize>0x4000</physicalRegionSize>
         <side>sideless</side>
         <readOnly/>
@@ -334,7 +325,7 @@ Layout Description
     <section>
         <description>HDAT Data (32K)</description>
         <eyeCatch>HDAT</eyeCatch>
-        <physicalOffset>0x3561000</physicalOffset>
+        <physicalOffset>0x2313000</physicalOffset>
         <physicalRegionSize>0x8000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -344,7 +335,7 @@ Layout Description
     <section>
         <description>Ultravisor binary image (1MB)</description>
         <eyeCatch>UVISOR</eyeCatch>
-        <physicalOffset>0x3569000</physicalOffset>
+        <physicalOffset>0x231B000</physicalOffset>
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -353,7 +344,7 @@ Layout Description
     <section>
         <description>Open CAPI Memory Buffer (OCMB) Firmware (1164K)</description>
         <eyeCatch>OCMBFW</eyeCatch>
-        <physicalOffset>0x3669000</physicalOffset>
+        <physicalOffset>0x241B000</physicalOffset>
         <physicalRegionSize>0x123000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
@@ -361,14 +352,14 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Eeprom Cache(512K)</description>
-        <eyeCatch>EECACHE</eyeCatch>
-        <physicalOffset>0x378C000</physicalOffset>
-        <physicalRegionSize>0x80000</physicalRegionSize>
+        <description>Hostboot Extended image (25 MB w/ ECC)</description>
+        <eyeCatch>HBI</eyeCatch>
+        <physicalOffset>0x253E000</physicalOffset>
+        <!--0x1AC2000 Is all the space that is left, do a little less than that-->
+        <physicalRegionSize>0x1900000</physicalRegionSize>  
+        <sha512Version/>
         <side>sideless</side>
+        <readOnly/>
         <ecc/>
-        <preserved/>
-        <reprovision/>
-        <clearOnEccErr/>
     </section>
 </pnor>

--- a/update_image.pl
+++ b/update_image.pl
@@ -368,15 +368,18 @@ sub processConvergedSections {
     }
     $sections{WOFDATA}{out}    = "$scratch_dir/wofdata.bin.ecc";
 
-    if (-e $memd_binary_filename)
+    if (checkForPnorPartition("MEMD", $parsed_pnor_layout))
     {
-        $sections{MEMD}{in}    = "$memd_binary_filename";
+        if (-e $memd_binary_filename)
+        {
+             $sections{MEMD}{in}    = "$memd_binary_filename";
+        }
+        else
+        {
+            print "WARNING: MEMD partition is not found, including blank binary instead\n";
+        }
+        $sections{MEMD}{out}       = "$scratch_dir/memd_extra_data.bin.ecc";
     }
-    else
-    {
-        print "WARNING: MEMD partition is not found, including blank binary instead\n";
-    }
-    $sections{MEMD}{out}       = "$scratch_dir/memd_extra_data.bin.ecc";
 
     # SMC COPY SAME ideas for hdat
     if(-e $hdat_binary_filename)


### PR DESCRIPTION
Previously when we attempted to removed the MEMD section from the
axone pnor layout in order to make more room for the hostboot sections
we broke the build for configs using this layout. This commit reapplys
the layout changes and also makes chagnes to the associated scripts
to handle not having a MEMD section in the layout.