### PR TITLE
Allow sbeOpDistribute to decide its interpreter

### DIFF
--- a/update_image.pl
+++ b/update_image.pl
@@ -278,7 +278,7 @@ if ($release eq "p9") {
 if ($release eq "p9") {
     my $hw_ref_image = $wink_binary_filename;
     $hw_ref_image =~ s/.hdr.bin.ecc//;
-    run_command("python $sbe_binary_dir/sbeOpDistribute.py --install --buildSbePart $hb_image_dir/buildSbePart.pl --hw_ref_image $hcode_dir/$hw_ref_image.bin --sbe_binary_filename $sbe_binary_filename --scratch_dir $scratch_dir --sbe_binary_dir $sbe_binary_dir");
+    run_command("$sbe_binary_dir/sbeOpDistribute.py --install --buildSbePart $hb_image_dir/buildSbePart.pl --hw_ref_image $hcode_dir/$hw_ref_image.bin --sbe_binary_filename $sbe_binary_filename --scratch_dir $scratch_dir --sbe_binary_dir $sbe_binary_dir");
 }
 else {
     run_command("cp $hb_binary_dir/$sbe_binary_filename $scratch_dir/");


### PR DESCRIPTION
This is required to build op-build with python3 as the default python like on Fedora 31