### PR TITLE
p9Layouts: Add hbrt proxy partition

### DIFF
--- a/p9Layouts/axonePnorLayout_64.xml
+++ b/p9Layouts/axonePnorLayout_64.xml
@@ -362,4 +362,14 @@ Layout Description
         <readOnly/>
         <ecc/>
     </section>
+    <section>
+        <description>Hostboot Runtime Proxy (32KB)</description>
+        <eyeCatch>HBRT_PROXY</eyeCatch>
+        <physicalOffset>0x3E3E000</physicalOffset>
+        <physicalRegionSize>0x8000</physicalRegionSize>
+        <sha512Version/>
+        <side>sideless</side>
+        <readOnly/>
+        <ecc/>
+    </section>
 </pnor>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -386,4 +386,14 @@ Layout Description
         <sha512Version/>
         <readOnly/>
     </section>
+    <section>
+        <description>Hostboot Runtime Proxy (32KB)</description>
+        <eyeCatch>HBRT_PROXY</eyeCatch>
+        <physicalOffset>0x36A9000</physicalOffset>
+        <physicalRegionSize>0x8000</physicalRegionSize>
+        <side>A</side>
+        <sha512Version/>
+        <readOnly/>
+        <ecc/>
+    </section>
 </pnor>


### PR DESCRIPTION
This patch adds the HBRT_PROXY (32KB) partition to the axone and default
PNOR layouts.

The hbrt-proxy source code is not upstream yet, we are planning to make it available soon.

Claudio