### PR TITLE
Mark HBEL partition preserved

### DIFF
--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -86,6 +86,7 @@ Layout Description
         <ecc/>
         <reprovision/>
         <clearOnEccErr/>
+        <preserved/>
     </section>
     <section>
         <description>Guard Data (20KiB)</description>


### PR DESCRIPTION
HBEL partition needs to survive code updates, since it contains error
logs that we report to BMC. This change marks the HBEL partition
perserved.

Signed-off-by: Ilya Smirnov <ismirno@us.ibm.com>