### PR TITLE
Mark HBEL partition preserved

### DIFF
--- a/p10Layouts/defaultPnorLayout_64.xml
+++ b/p10Layouts/defaultPnorLayout_64.xml
@@ -87,6 +87,7 @@ Layout Description
         <ecc/>
         <reprovision/>
         <clearOnEccErr/>
+        <preserved/>
     </section>
     <section>
         <description>Eeprom Cache(2.75MiB)</description>


### PR DESCRIPTION
HBEL partition needs to survive code updates, since it contains error
logs that we report to BMC. This change marks the HBEL partition
perserved.

Signed-off-by: Ilya Smirnov <ismirno@us.ibm.com>