### PR TITLE
P10: Increase PAYLOAD partition size to 1MB

### DIFF
--- a/p10Layouts/defaultPnorLayout_64.xml
+++ b/p10Layouts/defaultPnorLayout_64.xml
@@ -172,9 +172,9 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Payload (512KiB)</description>
+        <description>Payload (1MiB)</description>
         <eyeCatch>PAYLOAD</eyeCatch>
-        <physicalRegionSize>0x80000</physicalRegionSize>
+        <physicalRegionSize>0x100000</physicalRegionSize>
         <sha512Version/>
         <side>sideless</side>
         <readOnly/>


### PR DESCRIPTION
After adding P10 support PAYLOAD (skiboot) size is crossing
512K size. Hence increase PAYLOAD size to 1MB.

Signed-off-by: Ilya Smirnov <ismirno@us.ibm.com>