### PR TITLE
Support Optional Attribute/Targeting RW PNOR Partition

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -161,10 +161,10 @@ $build_pnor_command .= " --pnorOutBin $pnor_filename --pnorLayout $xml_layout_fi
 # Process HBD section and possibly HBD_RW section
 if (checkForPnorPartition("HBD_RW", $parsed_pnor_layout))
 {
-    $build_pnor_command .= " --binFile_HBD $scratch_dir/$targeting_RO_binary_filename";
     $build_pnor_command .= " --binFile_HBD_RW $scratch_dir/$targeting_RW_binary_filename";
 }
-else
+
+if (checkForPnorPartition("HBD", $parsed_pnor_layout))
 {
     $build_pnor_command .= " --binFile_HBD $scratch_dir/$targeting_binary_filename";
 }

--- a/update_image.pl
+++ b/update_image.pl
@@ -356,6 +356,12 @@ sub processConvergedSections {
     $sections{RINGOVD}{out}     = "$scratch_dir/ringOvd.bin";
 
     # Check if these optional sections exist in the PNOR layout file
+    if (checkForPnorPartition("HBD_RW", $parsed_pnor_layout))
+    {
+        # COMBO RO and RW (HBD, from above) and possibly the RW by itself
+        $sections{HBD_RW}{in}       = "$op_target_dir/$targeting_RW_binary_source";
+        $sections{HBD_RW}{out}      = "$scratch_dir/$targeting_RW_binary_filename";
+    }
     if (checkForPnorPartition("CAPP", $parsed_pnor_layout))
     {
         $sections{CAPP}{in}         = "$capp_binary_filename";


### PR DESCRIPTION
Add support for an optional Attribute/Targeting RW PNOR Partition (HBD_RW).

If the XML defining the PNOR layout HBD_RW exists then the HBD PNOR partition
will be flagged as HPT capable and this flag will be leveraged by Hostboot
at IPL time (see below for more info).

If the XML does NOT contain the HBD_RW section the HBD PNOR section
will perform legacy HBD partition support (no HPT optimizations).

The primary purpose of providing this capability is to allow PNOR HPT
(Hash Page Table) functionality to NOT pin the entire PNOR HBD section,
but to provide the HBD HPT enabled RO section to be paged out under
memory pressure during Hostboot IPL.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>