### PR TITLE
Enable HBD_RW for Hostboot IPL

### DIFF
--- a/p10Layouts/defaultPnorLayout_64.xml
+++ b/p10Layouts/defaultPnorLayout_64.xml
@@ -144,6 +144,13 @@ Layout Description
         <ecc/>
     </section>
     <section>
+        <description>Hostboot Data RW (2MiB)</description>
+        <eyeCatch>HBD_RW</eyeCatch>
+        <physicalRegionSize>0x200000</physicalRegionSize>
+        <side>sideless</side>
+        <ecc/>
+    </section>
+    <section>
         <description>SBE-IPL (Staging Area) (752KiB)</description>
         <eyeCatch>SBE</eyeCatch>
         <physicalRegionSize>0xBC000</physicalRegionSize>


### PR DESCRIPTION
Enable the HBD_RW PNOR section to allow the splitting of the HBD
and HBD RW data segments into their individual sections.  This will
allow the PNOR HPT (Hash Page Table) functionality to NOT pin the
entire PNOR HBD section, but to provide the HBD HPT enabled RO section
to be paged out under memory pressure during Hostboot IPL.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>