### PR TITLE
Add readOnly tag to HBD

### DIFF
--- a/p10Layouts/defaultPnorLayout_64.xml
+++ b/p10Layouts/defaultPnorLayout_64.xml
@@ -142,6 +142,7 @@ Layout Description
         <sha512Version/>
         <side>sideless</side>
         <ecc/>
+        <readOnly/>
     </section>
     <section>
         <description>Hostboot Data RW (2MiB)</description>


### PR DESCRIPTION
Since we have HBD_RW defined now, HBD only contains ready-only data.
