### PR TITLE
Remove HBD_RW Input File

### DIFF
--- a/update_image.pl
+++ b/update_image.pl
@@ -359,7 +359,6 @@ sub processConvergedSections {
     if (checkForPnorPartition("HBD_RW", $parsed_pnor_layout))
     {
         # COMBO RO and RW (HBD, from above) and possibly the RW by itself
-        $sections{HBD_RW}{in}       = "$op_target_dir/$targeting_RW_binary_source";
         $sections{HBD_RW}{out}      = "$scratch_dir/$targeting_RW_binary_filename";
     }
     if (checkForPnorPartition("CAPP", $parsed_pnor_layout))


### PR DESCRIPTION
This commit removes the input file for HBD_RW, since that PNOR partition
needs to be fully padded to its size as defined by the PNOR XML file.
The partition will now be built up during the boot with the persistent
RW attribute data.

Signed-off-by: Ilya Smirnov <ismirno@us.ibm.com>