### PR TITLE
P9: Migration effort to Red Hat 8

### DIFF
--- a/update_image.pl
+++ b/update_image.pl
@@ -278,7 +278,7 @@ if ($release eq "p9") {
 if ($release eq "p9") {
     my $hw_ref_image = $wink_binary_filename;
     $hw_ref_image =~ s/.hdr.bin.ecc//;
-    run_command("python $sbe_binary_dir/sbeOpDistribute.py --install --buildSbePart $hb_image_dir/buildSbePart.pl --hw_ref_image $hcode_dir/$hw_ref_image.bin --sbe_binary_filename $sbe_binary_filename --scratch_dir $scratch_dir --sbe_binary_dir $sbe_binary_dir");
+    run_command("python2 $sbe_binary_dir/sbeOpDistribute.py --install --buildSbePart $hb_image_dir/buildSbePart.pl --hw_ref_image $hcode_dir/$hw_ref_image.bin --sbe_binary_filename $sbe_binary_filename --scratch_dir $scratch_dir --sbe_binary_dir $sbe_binary_dir");
 }
 else {
     run_command("cp $hb_binary_dir/$sbe_binary_filename $scratch_dir/");


### PR DESCRIPTION
Update the call from python to python2 in migration effort to Red Hat 8.

RH7 has /bin/python defined in it's environment whereas RH8 will not. RH8
will not have a default of /bin/python but will only have /bin/python2 and
/bin/python3 defined.

Considering that for RH7, /bin/python is just a symbolic link to /bin/python2,
making this change to explicitly call python2 will have no detrimental affect.

Signed-off-by: Roland Veloz <rveloz@us.ibm.com>