### PR TITLE
Increase HBD to 2.5 MB

### DIFF
--- a/p10Layouts/defaultPnorLayout_64.xml
+++ b/p10Layouts/defaultPnorLayout_64.xml
@@ -129,9 +129,9 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Data (2MiB)</description>
+        <description>Hostboot Data (2.5MiB)</description>
         <eyeCatch>HBD</eyeCatch>
-        <physicalRegionSize>0x200000</physicalRegionSize>
+        <physicalRegionSize>0x280000</physicalRegionSize>
         <sha512Version/>
         <side>sideless</side>
         <readOnly/>


### PR DESCRIPTION
There has been an influx of new attributes that pushed HBD over its current size of 2MB. This commit increases the size to 2.5MB to accommodate.