### PR TITLE
Increase size of Attribute/Targeting (HBD) PNOR Partition

### DIFF
--- a/p10Layouts/defaultPnorLayout_64.xml
+++ b/p10Layouts/defaultPnorLayout_64.xml
@@ -129,9 +129,9 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Data (2.5MiB)</description>
+        <description>Hostboot Data (3.5MiB)</description>
         <eyeCatch>HBD</eyeCatch>
-        <physicalRegionSize>0x280000</physicalRegionSize>
+        <physicalRegionSize>0x380000</physicalRegionSize>
         <sha512Version/>
         <side>sideless</side>
         <readOnly/>


### PR DESCRIPTION
This commit increates the size of the hostboot Attribute/Targeting HBD PNOR partition to make room for the Everest changes required to support DDR5 Odyssey memory.