### PR TITLE
Update HBBL size to be consistent with FSP size without ECC

### DIFF
--- a/p11Layouts/defaultPnorLayout_64.xml
+++ b/p11Layouts/defaultPnorLayout_64.xml
@@ -201,18 +201,16 @@ Layout Description
     </section>
     <section>
         <!-- @HBBL_SIZE_SYNC@ -->
-        <description>Hostboot Bootloader (132KiB)</description>
+        <description>Hostboot Bootloader (136KiB)</description>
         <eyeCatch>HBBL</eyeCatch>
         <!-- Logical content of HBBL is -->
         <!-- V1 Secureboot Header of size 4KiB -->
-        <!-- + HBBL binary (including Securerom) with a Max size is 94KiB -->
+        <!-- + HBBL binary (including Securerom) with a Max size is 112KiB -->
         <!-- + V3 Secureboot header of size 15KiB -->
         <!-- Physical Size is Logical content, -->
         <!--  rouned up to nearest page (4KiB foundary), -->
-        <!--  plus ECC overhead, -->
-        <!--  then again rounded up to nearest page (4KiB) boundary, -->
-        <!--  so 132KiB in all -->
-        <physicalRegionSize>0x21000</physicalRegionSize>
+        <!--  so 136KiB in all -->
+        <physicalRegionSize>0x22000</physicalRegionSize>
         <side>sideless</side>
         <sha512Version/>
         <readOnly/>


### PR DESCRIPTION
-FSP size is 0x26000 (152 KiB), update size to page aligned
 eccless equivalent 0x22000 (136KiB)