### PR TITLE
update_image.pl: use python3 to run sbeOpDistribute.py

### DIFF
--- a/update_image.pl
+++ b/update_image.pl
@@ -278,7 +278,7 @@ if ($release eq "p9") {
 if ($release eq "p9") {
     my $hw_ref_image = $wink_binary_filename;
     $hw_ref_image =~ s/.hdr.bin.ecc//;
-    run_command("python2 $sbe_binary_dir/sbeOpDistribute.py --install --buildSbePart $hb_image_dir/buildSbePart.pl --hw_ref_image $hcode_dir/$hw_ref_image.bin --sbe_binary_filename $sbe_binary_filename --scratch_dir $scratch_dir --sbe_binary_dir $sbe_binary_dir");
+    run_command("python3 $sbe_binary_dir/sbeOpDistribute.py --install --buildSbePart $hb_image_dir/buildSbePart.pl --hw_ref_image $hcode_dir/$hw_ref_image.bin --sbe_binary_filename $sbe_binary_filename --scratch_dir $scratch_dir --sbe_binary_dir $sbe_binary_dir");
 }
 else {
     run_command("cp $hb_binary_dir/$sbe_binary_filename $scratch_dir/");


### PR DESCRIPTION
## Changes

python2 has reached its EOL and thus is unavailable on most modern Linux distros

`sbeOpDistribute.py` is python3-compatible, so invoke it with python3 during p9 image assembly.

## Related PR

https://github.com/open-power/op-build/pull/6803